### PR TITLE
Add text-only Applied Intelligence website shell (issue #4)

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>About | Applied Intelligence</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <header class="glass-nav"><div class="container nav-inner"><a class="brand" href="index.html">Applied Intelligence</a><nav><a href="index.html">Home</a></nav></div></header>
+    <main class="container"><section class="card"><h1>About</h1><p>Applied Intelligence is the parent ecosystem for specialized operational agents focused on analytics, continuous improvement, value justification, and communication.</p></section></main>
+    <footer class="container footer"><p>Applied Intelligence</p></footer>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/agents.html
+++ b/agents.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Agents | Applied Intelligence</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <header class="glass-nav"><div class="container nav-inner"><a class="brand" href="index.html">Applied Intelligence</a><nav><a href="index.html">Home</a></nav></div></header>
+    <main class="container">
+      <section class="card">
+        <h1>Agents</h1>
+        <p>One ecosystem. Separate agents. Clear roles.</p>
+        <ul>
+          <li>AI-Trace</li><li>AI-CIS</li><li>AI-ROI</li><li>AI-Case</li><li>AI-Quote</li><li>AI-RMA</li><li>AI-Connect</li><li>Document Formatter</li>
+        </ul>
+      </section>
+    </main>
+    <footer class="container footer"><p>Applied Intelligence</p></footer>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/ai-connect.html
+++ b/ai-connect.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AI-Connect | Applied Intelligence</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <header class="glass-nav"><div class="container nav-inner"><a class="brand" href="index.html">Applied Intelligence</a><nav><a href="index.html">Home</a></nav></div></header>
+    <main class="container"><section class="card"><h1>AI-Connect</h1><p>AI-Connect prepares the right people with the right information before action is needed.</p></section></main>
+    <footer class="container footer"><p>Applied Intelligence</p></footer>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/ai-trace.html
+++ b/ai-trace.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AI-Trace | Applied Intelligence</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <header class="glass-nav"><div class="container nav-inner"><a class="brand" href="index.html">Applied Intelligence</a><nav><a href="index.html">Home</a></nav></div></header>
+    <main class="container"><section class="card"><h1>AI-Trace</h1><p>AI-Trace exposes repeat problems, hidden cost, quality risk, and lost hours so recurring issues stop being patched and start being fixed.</p></section></main>
+    <footer class="container footer"><p>Applied Intelligence</p></footer>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/app.js
+++ b/app.js
@@ -1,0 +1,7 @@
+(function setYear() {
+  const footer = document.querySelector('.footer p');
+  if (!footer) return;
+
+  const year = new Date().getFullYear();
+  footer.textContent = `© ${year} Applied Intelligence · Standardize to Optimize`;
+})();

--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Contact | Applied Intelligence</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <header class="glass-nav"><div class="container nav-inner"><a class="brand" href="index.html">Applied Intelligence</a><nav><a href="index.html">Home</a></nav></div></header>
+    <main class="container"><section class="card"><h1>Contact</h1><p>Contact details are not yet available in this repository source bundle.</p><p>Placeholder path for future shared source alignment: <code>shared/source/project-registry.json</code>.</p></section></main>
+    <footer class="container footer"><p>Applied Intelligence</p></footer>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/framework.html
+++ b/framework.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Framework | Applied Intelligence</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <header class="glass-nav">
+      <div class="container nav-inner">
+        <a class="brand" href="index.html">Applied Intelligence</a>
+        <nav><a href="index.html">Home</a><a href="agents.html">Agents</a></nav>
+      </div>
+    </header>
+    <main class="container">
+      <section class="card">
+        <h1>Applied Intelligence Framework</h1>
+        <p>Built from the floor up.</p>
+        <p>The framework standardizes visibility, improvement, valuation, and communication into one aligned system.</p>
+      </section>
+    </main>
+    <footer class="container footer"><p>Applied Intelligence</p></footer>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,66 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Applied Intelligence | Standardize to Optimize</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <header class="glass-nav">
+      <div class="container nav-inner">
+        <a class="brand" href="index.html">Applied Intelligence</a>
+        <nav>
+          <a href="framework.html">Framework</a>
+          <a href="ai-connect.html">AI-Connect</a>
+          <a href="ai-trace.html">AI-Trace</a>
+          <a href="agents.html">Agents</a>
+          <a href="about.html">About</a>
+          <a href="contact.html">Contact</a>
+        </nav>
+      </div>
+    </header>
+
+    <main class="container">
+      <section class="hero card">
+        <p class="eyebrow">Applied Intelligence Framework</p>
+        <h1>Standardize to Optimize</h1>
+        <p>
+          Built from the floor up. One ecosystem. Separate agents. Clear roles.
+        </p>
+      </section>
+
+      <section class="grid">
+        <article class="card">
+          <h2>Framework</h2>
+          <p>
+            The website is the public-facing shell for the Applied Intelligence ecosystem.
+          </p>
+          <a href="framework.html">View framework overview</a>
+        </article>
+
+        <article class="card">
+          <h2>AI-Connect</h2>
+          <p>
+            Communication routing and permissions to prepare the right people with the right information.
+          </p>
+          <a href="ai-connect.html">Explore AI-Connect</a>
+        </article>
+
+        <article class="card">
+          <h2>AI-Trace</h2>
+          <p>
+            Visibility into repeat problems, hidden cost, quality risk, and lost hours.
+          </p>
+          <a href="ai-trace.html">Explore AI-Trace</a>
+        </article>
+      </section>
+    </main>
+
+    <footer class="container footer">
+      <p>Applied Intelligence · Standardize to Optimize</p>
+    </footer>
+
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,97 @@
+:root {
+  --bg: #080d18;
+  --surface: #0f1728;
+  --border: #1f2b45;
+  --text: #e9efff;
+  --muted: #a8b4d2;
+  --accent: #5aa4ff;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  background: radial-gradient(circle at top, #0f1b33 0%, var(--bg) 45%);
+  color: var(--text);
+  line-height: 1.5;
+}
+
+.container {
+  width: min(1100px, 92vw);
+  margin: 0 auto;
+}
+
+.glass-nav {
+  position: sticky;
+  top: 0;
+  backdrop-filter: blur(10px);
+  background: rgba(8, 13, 24, 0.75);
+  border-bottom: 1px solid var(--border);
+}
+
+.nav-inner {
+  min-height: 64px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.brand {
+  color: var(--text);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+}
+
+nav a,
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+main {
+  padding: 2.5rem 0 2rem;
+}
+
+.hero h1 {
+  margin: 0.2rem 0 0.4rem;
+  font-size: clamp(1.8rem, 3.8vw, 2.8rem);
+}
+
+.eyebrow {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.grid {
+  margin-top: 1.2rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  gap: 1rem;
+}
+
+.card {
+  background: linear-gradient(180deg, rgba(15, 23, 40, 0.95), rgba(12, 19, 34, 0.95));
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 1.1rem 1.2rem;
+}
+
+.card h2 {
+  margin-top: 0;
+}
+
+.footer {
+  padding: 1rem 0 2rem;
+  color: var(--muted);
+}


### PR DESCRIPTION
### Motivation
- Provide a minimal, text-only static website shell for issue #4 so the repository contains a public-facing presentation aligned with the Applied Intelligence identity and source bundle.

### Description
- Added a simple site shell with `index.html`, `framework.html`, `ai-connect.html`, `ai-trace.html`, `agents.html`, `about.html`, `contact.html`, `style.css`, and `app.js` following the requested file types only.
- Implemented a dark-navy, glass-like UI with a sticky top navigation, rounded card components, and a responsive grid layout in `style.css`.
- Added a small runtime helper in `app.js` to set the footer year dynamically and kept all pages text-only (no images or binaries added).
- Left a placeholder on the Contact page pointing to the expected shared source path `shared/source/project-registry.json` to indicate missing contact data/assets.

### Testing
- Ran `git status --short` and `git rev-parse --short HEAD` to verify the working tree and commit id, both succeeded.
- Changes were committed and a pull request was created using the repository tooling (PR created, not merged).
- Did not run `npm run build` because no `package.json` exists in this repository, so no build step was executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee204ef0788323890f272c90efab5f)