### PR TITLE
Add site pages, styles, and client JS for Applied Intelligence website

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+<meta name="theme-color" content="#050914" />
+<meta name="apple-mobile-web-app-capable" content="yes" />
+<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+<title>About Christopher Hilton - Applied Intelligence</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<header class="site-header">
+  <div class="container nav">
+    <a class="brand" href="index.html"><div class="brand-copy"><strong>Applied Intelligence</strong><span>APPLIED INTELLIGENCE FRAMEWORK</span></div></a>
+    <button class="nav-toggle" type="button" aria-expanded="false" aria-label="Toggle navigation" data-nav-toggle>
+      <span></span><span></span><span></span>
+    </button>
+    <nav class="nav-links" data-nav-links><a class="" href="index.html">Home</a><a class="" href="framework.html">Framework</a><a class="" href="ai-connect.html">AI-Connect</a><a class="" href="ai-trace.html">AI-Trace</a><a class="" href="agents.html">Agents</a><a class="" href="about.html">About</a><a class="" href="contact.html">Contact</a></nav>
+  </div>
+</header>
+<main>
+
+<section class="page-hero about-hero">
+  <div class="container page-grid">
+    <div>
+      <div class="kicker">Founder</div>
+      <h1>Built from the floor up.</h1>
+      <p>Christopher Hilton built Applied Intelligence to simplify the broken core ecosystem of manufacturing through small, connected systems for visibility, coordination, improvement, and measurable execution.</p>
+      <div class="hero-actions"><a class="btn primary" href="framework.html">Open the framework</a><a class="btn ghost" href="contact.html">Contact</a></div>
+    </div>
+    <div class="hero-panel chrome compact-panel">
+      <div class="topline"><h3>Focus</h3><span class="tag silver">Founder</span></div>
+      <p>Applied Intelligence brings automation, manufacturing engineering, robotics, and Lean Six Sigma thinking into one connected framework built for real operational friction.</p>
+      <div class="chips"><span class="chip">Automation</span><span class="chip">Manufacturing Engineering</span><span class="chip">Robotics</span><span class="chip">Lean Six Sigma</span></div>
+    </div>
+  </div>
+</section>
+<section class="section">
+  <div class="container split">
+    <div class="surface">
+      <div class="topline"><h3>Founder story</h3><span class="tag blue">About</span></div>
+      <p class="section-copy">After nearly twenty years of watching the same manufacturing problems get patched instead of solved, Christopher Hilton saw the real gap clearly: the fixes existed, but the system did not.</p>
+      <p class="section-copy">Applied Intelligence was built to close that gap through small connected systems that make issues visible, route ownership clearly, standardize response, and create real improvement momentum.</p>
+    </div>
+    <div class="surface">
+      <div class="topline"><h3>Background</h3><span class="tag teal">Experience</span></div>
+      <p class="section-copy">Christopher Hilton brings hands-on experience across automation and manufacturing engineering, cobot welding, fixture design, troubleshooting, and production optimization.</p>
+      <p class="section-copy">That experience shapes Applied Intelligence into something practical, structured, and built for real-world use — not theory.</p>
+      <div class="chips compact-chips"><span class="chip">Automation & Manufacturing Engineering</span><span class="chip">Cobot Welding</span><span class="chip">Fixture Design</span><span class="chip">Production Optimization</span></div>
+    </div>
+  </div>
+</section>
+
+</main>
+<div class="dock-wrap">
+  <div class="container">
+    <div class="dock chrome" data-mobile-dock><nav class="dock-nav"><a class="" href="index.html">Home</a><a class="" href="framework.html">Framework</a><a class="" href="ai-connect.html">Connect</a><a class="" href="ai-trace.html">Trace</a><a class="active dock-secondary" href="about.html">About</a><a class="dock-secondary" href="contact.html">Contact</a></nav></div>
+  </div>
+</div>
+<footer class="footer"><div class="container">© <span data-year></span> Applied Intelligence</div></footer>
+<script src="app.js"></script>
+</body></html>

--- a/agents.html
+++ b/agents.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+<meta name="theme-color" content="#050914" />
+<meta name="apple-mobile-web-app-capable" content="yes" />
+<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+<title>Agents - Applied Intelligence</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<header class="site-header">
+  <div class="container nav">
+    <a class="brand" href="index.html"><div class="brand-copy"><strong>Applied Intelligence</strong><span>APPLIED INTELLIGENCE FRAMEWORK</span></div></a>
+    <button class="nav-toggle" type="button" aria-expanded="false" aria-label="Toggle navigation" data-nav-toggle>
+      <span></span><span></span><span></span>
+    </button>
+    <nav class="nav-links" data-nav-links><a class="" href="index.html">Home</a><a class="" href="framework.html">Framework</a><a class="" href="ai-connect.html">AI-Connect</a><a class="" href="ai-trace.html">AI-Trace</a><a class="active" href="agents.html">Agents</a><a class="" href="about.html">About</a><a class="" href="contact.html">Contact</a></nav>
+  </div>
+</header>
+<main>
+
+<section class="page-hero">
+  <div class="container page-grid">
+    <div>
+      <div class="kicker">Agent directory</div>
+      <h1>Specialist systems under one umbrella.</h1>
+      <p>Each system owns a clear role. The website presents the ecosystem publicly. The master source defines it underneath.</p>
+    </div>
+    <div class="hero-panel chrome">
+      <div class="topline"><h3>Ecosystem rule</h3><span class="tag silver">Core principle</span></div>
+      <p>One ecosystem. Separate agents. Clear roles.</p>
+    </div>
+  </div>
+</section>
+<section class="section">
+  <div class="container cards-3">
+    <a class="card" href="ai-connect.html" style="text-decoration:none;color:inherit"><div class="topline"><h3>AI-Connect</h3><span class="tag teal">Connect</span></div><p>Communication, routing, notification, permissions, escalation, handoffs, and coordination.</p></a>
+    <a class="card" href="ai-trace.html" style="text-decoration:none;color:inherit"><div class="topline"><h3>AI-Trace</h3><span class="tag blue">Trace</span></div><p>Visibility, logging, dashboards, repeat patterns, and issue ranking.</p></a>
+    <div class="card"><div class="topline"><h3>AI-CIS</h3><span class="tag copper">Improve</span></div><p>Continuous improvement engine with LIR, LIR-P, LIR-E, and Control ownership.</p></div>
+    <div class="card"><div class="topline"><h3>AI-ROI</h3><span class="tag green">ROI</span></div><p>Business case, payback logic, and financial justification after the work is validated.</p></div>
+    <div class="card"><div class="topline"><h3>AI-Case</h3><span class="tag indigo">Case</span></div><p>Case study storytelling and portfolio-ready project narratives.</p></div>
+    <div class="card"><div class="topline"><h3>AI-RMA</h3><span class="tag red">RMA</span></div><p>Containment, failure tracing, corrective action, and return structure.</p></div>
+  </div>
+</section>
+<section class="section">
+  <div class="container anchor-strip">
+    <div class="anchor-pill"><strong>Visibility</strong><p>AI-Trace shows the picture clearly.</p></div>
+    <div class="anchor-pill"><strong>Improvement</strong><p>AI-CIS finds and structures the improvement.</p></div>
+    <div class="anchor-pill"><strong>Coordination</strong><p>AI-Connect makes sure the work reaches the right people.</p></div>
+  </div>
+</section>
+
+</main>
+<div class="dock-wrap">
+  <div class="container">
+    <div class="dock chrome" data-mobile-dock><nav class="dock-nav"><a class="" href="index.html">Home</a><a class="" href="framework.html">Framework</a><a class="" href="ai-connect.html">Connect</a><a class="" href="ai-trace.html">Trace</a><a class="dock-secondary" href="about.html">About</a><a class="dock-secondary" href="contact.html">Contact</a></nav></div>
+  </div>
+</div>
+<footer class="footer"><div class="container">© <span data-year></span> Applied Intelligence</div></footer>
+<script src="app.js"></script>
+</body></html>

--- a/ai-connect.html
+++ b/ai-connect.html
@@ -1,0 +1,111 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+<meta name="theme-color" content="#050914" />
+<meta name="apple-mobile-web-app-capable" content="yes" />
+<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+<title>AI-Connect - Applied Intelligence</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<header class="site-header">
+  <div class="container nav">
+    <a class="brand" href="index.html"><div class="brand-copy"><strong>Applied Intelligence</strong><span>APPLIED INTELLIGENCE FRAMEWORK</span></div></a>
+    <button class="nav-toggle" type="button" aria-expanded="false" aria-label="Toggle navigation" data-nav-toggle>
+      <span></span><span></span><span></span>
+    </button>
+    <nav class="nav-links" data-nav-links><a class="" href="index.html">Home</a><a class="" href="framework.html">Framework</a><a class="active" href="ai-connect.html">AI-Connect</a><a class="" href="ai-trace.html">AI-Trace</a><a class="" href="agents.html">Agents</a><a class="" href="about.html">About</a><a class="" href="contact.html">Contact</a></nav>
+  </div>
+</header>
+<main>
+
+<section class="page-hero">
+  <div class="container page-grid">
+    <div>
+      <div class="kicker">Communication, routing, and coordination layer</div>
+      <h1>Ties the ecosystem together without replacing it.</h1>
+      <p>AI-Connect prepares the right people with the right information before action is needed. It connects departments, ownership, routing, permissions, alerts, handoffs, and follow-through.</p>
+      <div class="hero-actions"><a class="btn primary" href="agents.html">Back to Agents</a><a class="btn ghost" href="framework.html">View Framework</a></div>
+    </div>
+    <div class="hero-panel chrome">
+      <div class="topline"><h3>AI-Connect</h3><span class="tag teal">Role focus</span></div>
+      <p>AI-Connect is the connective operating layer of Applied Intelligence. It connects people, departments, reports, alerts, meetings, permissions, workflows, and agent handoffs so nothing important gets lost between people, departments, or decisions.</p>
+      <div class="chips"><span class="chip">Routing</span><span class="chip">Permissions</span><span class="chip">Escalation</span><span class="chip">Handoffs</span></div>
+    </div>
+  </div>
+</section>
+<section class="section">
+  <div class="container story-grid">
+    <div class="story-card surface"><div class="topline"><h3>Routes reports</h3><span class="tag teal">Owner path</span></div><p>Welding to welding lead. Laser to laser lead. Cross-functional issues to multiple owners when the work actually crosses departments.</p></div>
+    <div class="story-card surface"><div class="topline"><h3>Controls visibility</h3><span class="tag silver">Access</span></div><p>Standard users, leads, supervisors, managers, and executives should not all see the system the same way.</p></div>
+    <div class="story-card surface"><div class="topline"><h3>Prepares action</h3><span class="tag blue">Timing</span></div><p>Meeting prep, alerts, escalations, and handoffs exist so the signal does not die between people and decisions.</p></div>
+  </div>
+</section>
+<section class="section">
+  <div class="container split">
+    <div class="surface">
+      <div class="topline"><h3>Valid commands</h3><span class="tag teal">Commands</span></div>
+      <div class="command-list">
+        <div class="command-pill">Run Connect</div>
+        <div class="command-pill">Run Connect Route</div>
+        <div class="command-pill">Run Connect Notify</div>
+        <div class="command-pill">Run Connect Alert</div>
+        <div class="command-pill">Run Connect Chat</div>
+        <div class="command-pill">Run Connect Permissions</div>
+        <div class="command-pill">Run Connect Access</div>
+        <div class="command-pill">Run Connect Meeting</div>
+        <div class="command-pill">Run Connect Escalation</div>
+        <div class="command-pill">Run Connect Handoff</div>
+      </div>
+    </div>
+    <div class="surface">
+      <div class="topline"><h3>Boundaries</h3><span class="tag silver">Limits</span></div>
+      <div class="command-list">
+        <div class="command-pill">Does not own root cause analysis</div>
+        <div class="command-pill">Does not own corrective action writing</div>
+        <div class="command-pill">Does not own continuous improvement logic</div>
+        <div class="command-pill">Does not own ROI or case study generation</div>
+        <div class="command-pill">Connects the work. Does not replace the work.</div>
+      </div>
+    </div>
+  </div>
+</section>
+<section class="section">
+  <div class="container anchor-strip">
+    <div class="anchor-pill"><strong>Chat</strong><p>Communication stays tied to real work, not generic side chatter.</p></div>
+    <div class="anchor-pill"><strong>Broadcast</strong><p>Leadership can route information cleanly across the company without the message getting buried.</p></div>
+    <div class="anchor-pill"><strong>Handoff</strong><p>Outputs move from department to department with ownership visible and next action clear.</p></div>
+  </div>
+</section>
+
+<section class="section">
+  <div class="container split">
+    <div class="surface">
+      <div class="topline"><h3>Routing model</h3><span class="tag teal">Flow</span></div>
+      <p class="section-copy">AI-Connect should make the next owner obvious. The right lane gets the right issue, in the right order, before momentum disappears.</p>
+      <div class="command-list">
+        <div class="command-pill">Issue appears</div>
+        <div class="command-pill">Correct people are notified</div>
+        <div class="command-pill">Ownership becomes visible</div>
+        <div class="command-pill">Handoff stays attached to the work</div>
+      </div>
+    </div>
+    <div class="surface">
+      <div class="topline"><h3>Why it matters</h3><span class="tag blue">Follow-through</span></div>
+      <p class="section-copy">Most systems lose the issue between departments, meetings, and inboxes. AI-Connect exists to keep the signal alive long enough for the right people to act on it.</p>
+      <div class="section-rail"><span>Routing</span><span>Alerts</span><span>Meeting prep</span><span>Broadcast</span></div>
+    </div>
+  </div>
+</section>
+
+</main>
+<div class="dock-wrap">
+  <div class="container">
+    <div class="dock chrome" data-mobile-dock><nav class="dock-nav"><a class="" href="index.html">Home</a><a class="" href="framework.html">Framework</a><a class="active" href="ai-connect.html">Connect</a><a class="" href="ai-trace.html">Trace</a><a class="dock-secondary" href="about.html">About</a><a class="dock-secondary" href="contact.html">Contact</a></nav></div>
+  </div>
+</div>
+<footer class="footer"><div class="container">© <span data-year></span> Applied Intelligence</div></footer>
+<script src="app.js"></script>
+</body></html>

--- a/ai-trace.html
+++ b/ai-trace.html
@@ -1,0 +1,84 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+<meta name="theme-color" content="#050914" />
+<meta name="apple-mobile-web-app-capable" content="yes" />
+<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+<title>AI-Trace - Applied Intelligence</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<header class="site-header">
+  <div class="container nav">
+    <a class="brand" href="index.html"><div class="brand-copy"><strong>Applied Intelligence</strong><span>APPLIED INTELLIGENCE FRAMEWORK</span></div></a>
+    <button class="nav-toggle" type="button" aria-expanded="false" aria-label="Toggle navigation" data-nav-toggle>
+      <span></span><span></span><span></span>
+    </button>
+    <nav class="nav-links" data-nav-links><a class="" href="index.html">Home</a><a class="" href="framework.html">Framework</a><a class="" href="ai-connect.html">AI-Connect</a><a class="active" href="ai-trace.html">AI-Trace</a><a class="" href="agents.html">Agents</a><a class="" href="about.html">About</a><a class="" href="contact.html">Contact</a></nav>
+  </div>
+</header>
+<main>
+
+<section class="page-hero">
+  <div class="container page-grid">
+    <div>
+      <div class="kicker">AI-Trace workflow</div>
+      <h1>Capture, rank, and expose the pattern fast.</h1>
+      <p>Borrowed from the app’s operating interface: single entry, batch import, CIS handoff, and a clean analytics layer built around ranked visibility rather than crowded KPI tiles.</p>
+      <div class="section-rail"><span>Single entry</span><span>Batch import</span><span>CIS handoff</span></div>
+    </div>
+    <div class="hero-panel chrome">
+      <div class="topline"><h3>Why Trace matters</h3><span class="tag blue">Visibility</span></div>
+      <p>Production reacts first. People improvise. Work moves on. AI-Trace exists so the issue does not disappear before somebody has time to fix it correctly.</p>
+    </div>
+  </div>
+</section>
+<section class="section">
+  <div class="container story-grid">
+    <div class="story-card surface"><div class="topline"><h3>Single Entry</h3><span class="tag blue">Capture</span></div><p>Fast friction logging when something happens in the moment and needs to be captured before it gets lost.</p></div>
+    <div class="story-card surface"><div class="topline"><h3>Batch Import</h3><span class="tag silver">Scale</span></div><p>Bring in repeated issues, history, or grouped records without forcing manual one-by-one entry.</p></div>
+    <div class="story-card surface"><div class="topline"><h3>CIS Handoff</h3><span class="tag copper">Improve</span></div><p>Escalate the signal into structured improvement when repeated friction deserves ownership and correction.</p></div>
+  </div>
+</section>
+<section class="section">
+  <div class="container split">
+    <div class="surface">
+      <div class="topline"><h3>Recent system signals</h3><span class="tag blue">Analytics</span></div>
+      <div class="analytics-list">
+        <div class="bar-row"><span>Delay</span><div class="bar-track"><div class="bar-fill" style="width:100%"></div></div><div class="bar-val">100</div></div>
+        <div class="bar-row"><span>Setup</span><div class="bar-track"><div class="bar-fill" style="width:80%"></div></div><div class="bar-val">80</div></div>
+        <div class="bar-row"><span>Tags</span><div class="bar-track"><div class="bar-fill" style="width:60%"></div></div><div class="bar-val">60</div></div>
+        <div class="bar-row"><span>Hardware</span><div class="bar-track"><div class="bar-fill" style="width:40%"></div></div><div class="bar-val">40</div></div>
+      </div>
+    </div>
+    <div class="surface">
+      <div class="topline"><h3>Valid commands</h3><span class="tag silver">Commands</span></div>
+      <div class="command-list">
+        <div class="command-pill">Run Trace Batch</div>
+        <div class="command-pill">Run Trace Log</div>
+        <div class="command-pill">Run Trace Summary</div>
+        <div class="command-pill">Run Trace Pattern</div>
+        <div class="command-pill">Run Trace Escalation</div>
+      </div>
+    </div>
+  </div>
+</section>
+<section class="section">
+  <div class="container anchor-strip">
+    <div class="anchor-pill"><strong>Expose the signal</strong><p>Visibility matters because unresolved friction repeats itself quietly.</p></div>
+    <div class="anchor-pill"><strong>Rank the pattern</strong><p>The system should make it obvious which issue deserves attention first.</p></div>
+    <div class="anchor-pill"><strong>Escalate clearly</strong><p>When the threshold is crossed, AI-Trace should point the work into AI-CIS.</p></div>
+  </div>
+</section>
+
+</main>
+<div class="dock-wrap">
+  <div class="container">
+    <div class="dock chrome" data-mobile-dock><nav class="dock-nav"><a class="" href="index.html">Home</a><a class="" href="framework.html">Framework</a><a class="" href="ai-connect.html">Connect</a><a class="active" href="ai-trace.html">Trace</a><a class="dock-secondary" href="about.html">About</a><a class="dock-secondary" href="contact.html">Contact</a></nav></div>
+  </div>
+</div>
+<footer class="footer"><div class="container">© <span data-year></span> Applied Intelligence</div></footer>
+<script src="app.js"></script>
+</body></html>

--- a/app.js
+++ b/app.js
@@ -1,0 +1,78 @@
+document.querySelectorAll("[data-year]").forEach(el => {
+  el.textContent = new Date().getFullYear();
+});
+
+const navToggle = document.querySelector('[data-nav-toggle]');
+const navLinks = document.querySelector('[data-nav-links]');
+
+if (navToggle && navLinks) {
+  const closeNav = () => {
+    navLinks.classList.remove('is-open');
+    navToggle.setAttribute('aria-expanded', 'false');
+    document.body.classList.remove('nav-open');
+  };
+
+  navToggle.addEventListener('click', () => {
+    const willOpen = !navLinks.classList.contains('is-open');
+    navLinks.classList.toggle('is-open', willOpen);
+    navToggle.setAttribute('aria-expanded', willOpen ? 'true' : 'false');
+    document.body.classList.toggle('nav-open', willOpen);
+  });
+
+  navLinks.querySelectorAll('a').forEach(link => {
+    link.addEventListener('click', closeNav);
+  });
+
+  window.addEventListener('resize', () => {
+    if (window.innerWidth > 760) closeNav();
+  });
+}
+
+const dock = document.querySelector('[data-mobile-dock]');
+if (dock) {
+  let lastY = window.scrollY;
+  let stopTimer = null;
+  let hidden = false;
+  const isPhone = () => window.innerWidth <= 760;
+
+  const showDock = () => {
+    dock.classList.remove('is-hidden');
+    hidden = false;
+  };
+
+  const hideDock = () => {
+    dock.classList.add('is-hidden');
+    hidden = true;
+  };
+
+  const queueShow = () => {
+    clearTimeout(stopTimer);
+    stopTimer = setTimeout(() => {
+      if (isPhone()) showDock();
+    }, 120);
+  };
+
+  const onScroll = () => {
+    if (!isPhone()) {
+      showDock();
+      lastY = window.scrollY;
+      return;
+    }
+    const y = window.scrollY;
+    const delta = y - lastY;
+    if (y < 40) {
+      showDock();
+    } else if (delta > 8 && !hidden) {
+      hideDock();
+    } else if (delta < -4) {
+      showDock();
+    }
+    lastY = y;
+    queueShow();
+  };
+
+  window.addEventListener('scroll', onScroll, { passive: true });
+  window.addEventListener('resize', () => {
+    if (!isPhone()) showDock();
+  });
+}

--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+<meta name="theme-color" content="#050914" />
+<meta name="apple-mobile-web-app-capable" content="yes" />
+<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+<title>Contact - Applied Intelligence</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<header class="site-header">
+  <div class="container nav">
+    <a class="brand" href="index.html"><div class="brand-copy"><strong>Applied Intelligence</strong><span>APPLIED INTELLIGENCE FRAMEWORK</span></div></a>
+    <button class="nav-toggle" type="button" aria-expanded="false" aria-label="Toggle navigation" data-nav-toggle>
+      <span></span><span></span><span></span>
+    </button>
+    <nav class="nav-links" data-nav-links><a class="" href="index.html">Home</a><a class="" href="framework.html">Framework</a><a class="" href="ai-connect.html">AI-Connect</a><a class="" href="ai-trace.html">AI-Trace</a><a class="" href="agents.html">Agents</a><a class="" href="about.html">About</a><a class="active" href="contact.html">Contact</a></nav>
+  </div>
+</header>
+<main>
+
+<section class="page-hero">
+  <div class="container page-grid">
+    <div>
+      <div class="kicker">Contact</div>
+      <h1>Start the conversation.</h1>
+      <p>Applied Intelligence is ready for project conversations, ecosystem walkthroughs, founder contact, and product-direction discussions.</p>
+    </div>
+    <div class="hero-panel chrome">
+      <div class="topline"><h3>Best starting point</h3><span class="tag silver">Contact</span></div>
+      <p class="notice">hello@appliedintelco.com</p>
+      <p>Use this for project inquiries, partnerships, demos, founder contact, and framework conversations.</p>
+    </div>
+  </div>
+</section>
+<section class="section">
+  <div class="container anchor-strip">
+    <div class="anchor-pill"><strong>Projects</strong><p>Applied Intelligence system work, ecosystem planning, and website/app alignment.</p></div>
+    <div class="anchor-pill"><strong>Partnerships</strong><p>Manufacturing, robotics, workflow, and product collaboration.</p></div>
+    <div class="anchor-pill"><strong>Demos</strong><p>Framework walkthroughs, ecosystem overview, and operating-interface conversations.</p></div>
+  </div>
+</section>
+<section class="section">
+  <div class="container split">
+    <div class="surface">
+      <div class="topline"><h3>Good fit</h3><span class="tag teal">Use cases</span></div>
+      <div class="command-list">
+        <div class="command-pill">Manufacturing system design</div>
+        <div class="command-pill">Workflow visibility and routing</div>
+        <div class="command-pill">App-to-website ecosystem strategy</div>
+      </div>
+    </div>
+    <div class="surface">
+      <div class="topline"><h3>Best message to send</h3><span class="tag blue">Brief</span></div>
+      <p class="section-copy">Share what you are building, where the friction lives, and what kind of visibility, coordination, or improvement support you want from the framework.</p>
+    </div>
+  </div>
+</section>
+
+</main>
+<div class="dock-wrap">
+  <div class="container">
+    <div class="dock chrome" data-mobile-dock><nav class="dock-nav"><a class="" href="index.html">Home</a><a class="" href="framework.html">Framework</a><a class="" href="ai-connect.html">Connect</a><a class="" href="ai-trace.html">Trace</a><a class="dock-secondary" href="about.html">About</a><a class="active dock-secondary" href="contact.html">Contact</a></nav></div>
+  </div>
+</div>
+<footer class="footer"><div class="container">© <span data-year></span> Applied Intelligence</div></footer>
+<script src="app.js"></script>
+</body></html>

--- a/framework.html
+++ b/framework.html
@@ -1,0 +1,84 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+<meta name="theme-color" content="#050914" />
+<meta name="apple-mobile-web-app-capable" content="yes" />
+<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+<title>Framework - Applied Intelligence</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<header class="site-header">
+  <div class="container nav">
+    <a class="brand" href="index.html"><div class="brand-copy"><strong>Applied Intelligence</strong><span>APPLIED INTELLIGENCE FRAMEWORK</span></div></a>
+    <button class="nav-toggle" type="button" aria-expanded="false" aria-label="Toggle navigation" data-nav-toggle>
+      <span></span><span></span><span></span>
+    </button>
+    <nav class="nav-links" data-nav-links><a class="" href="index.html">Home</a><a class="active" href="framework.html">Framework</a><a class="" href="ai-connect.html">AI-Connect</a><a class="" href="ai-trace.html">AI-Trace</a><a class="" href="agents.html">Agents</a><a class="" href="about.html">About</a><a class="" href="contact.html">Contact</a></nav>
+  </div>
+</header>
+<main>
+
+<section class="page-hero">
+  <div class="container page-grid">
+    <div>
+      <div class="kicker">Framework shell</div>
+      <h1>The ecosystem stays aligned.</h1>
+      <p>Applied Intelligence presents the parent system publicly while keeping specialist roles clean underneath it. The website borrows the flagship app’s spacing, chrome, dock logic, and card language without becoming a dashboard clone.</p>
+      <div class="section-rail"><span>Parent ecosystem</span><span>Specialist systems</span><span>Shared language</span></div>
+    </div>
+    <div class="hero-panel chrome">
+      <div class="topline"><h3>Core rule</h3><span class="tag silver">Boundary</span></div>
+      <p>The app is the operating layer. The website is the framework shell. They should feel like one ecosystem, not one duplicated screen.</p>
+    </div>
+  </div>
+</section>
+<section class="section">
+  <div class="container cards-3">
+    <div class="card"><div class="topline"><h3>AI-Connect</h3><span class="tag teal">Coordination</span></div><p>Routes work, informs the right people, controls visibility, and keeps ownership from getting lost.</p></div>
+    <div class="card"><div class="topline"><h3>AI-Trace</h3><span class="tag blue">Visibility</span></div><p>Shows the picture clearly through logging, dashboards, patterns, and escalation signals.</p></div>
+    <div class="card"><div class="topline"><h3>AI-CIS</h3><span class="tag copper">Improvement</span></div><p>Structures the improvement with LIR, LIR-P, LIR-E, and Control inside a standardized system.</p></div>
+    <div class="card"><div class="topline"><h3>AI-ROI</h3><span class="tag green">Value</span></div><p>Receives validated inputs and turns them into payback, business case, and financial clarity.</p></div>
+    <div class="card"><div class="topline"><h3>AI-Case</h3><span class="tag indigo">Story</span></div><p>Tells the story after the work is real and turns solved problems into portfolio-ready case studies.</p></div>
+    <div class="card"><div class="topline"><h3>AI-RMA</h3><span class="tag red">Corrective</span></div><p>Contains risk, traces failures, and drives corrective action without drifting into other lanes.</p></div>
+  </div>
+</section>
+<section class="section">
+  <div class="container split">
+    <div class="surface">
+      <h2 class="section-title">Priority-first system flow.</h2>
+      <p class="section-copy">The framework stays useful when the sequence stays simple: expose the signal, rank the problem, route ownership, verify completion, and keep the accountability trail intact.</p>
+      <div class="command-list">
+        <div class="command-pill">Expose the signal</div>
+        <div class="command-pill">Rank the problem</div>
+        <div class="command-pill">Route the issue</div>
+        <div class="command-pill">Verify completion</div>
+        <div class="command-pill">Show measurable improvement</div>
+      </div>
+    </div>
+    <div class="surface">
+      <h2 class="section-title">Why the shell matters.</h2>
+      <p class="section-copy">The shell gives Applied Intelligence a clear public face. The app remains the operating interface. When both surfaces share the same language, the system feels intentional instead of fragmented.</p>
+      <div class="section-rail"><span>Public shell</span><span>Operating layer</span><span>Shared source</span></div>
+    </div>
+  </div>
+</section>
+<section class="section">
+  <div class="container story-grid">
+    <div class="story-card surface"><div class="topline"><h3>Website</h3><span class="tag silver">Narrative</span></div><p>Cleaner, calmer, and more narrative. This is where the framework becomes legible to the outside world.</p></div>
+    <div class="story-card surface"><div class="topline"><h3>iPad app</h3><span class="tag blue">Flagship</span></div><p>The flagship operating experience. This is the design reference for spacing, chrome, dock behavior, and system rhythm.</p></div>
+    <div class="story-card surface"><div class="topline"><h3>Phone</h3><span class="tag teal">Support</span></div><p>A supporting layer for real-time use on the move, simplified where needed without breaking the ecosystem language.</p></div>
+  </div>
+</section>
+
+</main>
+<div class="dock-wrap">
+  <div class="container">
+    <div class="dock chrome" data-mobile-dock><nav class="dock-nav"><a class="" href="index.html">Home</a><a class="active" href="framework.html">Framework</a><a class="" href="ai-connect.html">Connect</a><a class="" href="ai-trace.html">Trace</a><a class="dock-secondary" href="about.html">About</a><a class="dock-secondary" href="contact.html">Contact</a></nav></div>
+  </div>
+</div>
+<footer class="footer"><div class="container">© <span data-year></span> Applied Intelligence</div></footer>
+<script src="app.js"></script>
+</body></html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,201 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+<meta name="theme-color" content="#050914" />
+<meta name="apple-mobile-web-app-capable" content="yes" />
+<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+<title>Applied Intelligence</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body class="home-v16">
+<header class="site-header">
+  <div class="container nav nav-v16">
+    <a class="brand brand-v16" href="index.html">
+      <img class="brand-icon" src="assets/logo-icon.png" alt="Applied Intelligence logo" />
+      <div class="brand-copy">
+        <strong>Applied Intelligence</strong>
+        <span>APPLIED INTELLIGENCE FRAMEWORK</span>
+      </div>
+    </a>
+    <button class="nav-toggle" type="button" aria-expanded="false" aria-label="Toggle navigation" data-nav-toggle>
+      <span></span><span></span><span></span>
+    </button>
+    <nav class="nav-links nav-links-v16" data-nav-links>
+      <a class="active" href="index.html">Home</a>
+      <a href="framework.html">Framework</a>
+      <a href="ai-connect.html">AI-Connect</a>
+      <a href="ai-trace.html">AI-Trace</a>
+      <a href="agents.html">Agents</a>
+      <a href="contact.html">Contact</a>
+    </nav>
+  </div>
+</header>
+
+<main>
+  <section class="hero hero-v16">
+    <div class="container hero-layout-v16">
+      <div class="hero-left-v16">
+        <div class="kicker">Flagship framework suite</div>
+        <h1>Standardize to<br>Optimize.</h1>
+        <p>Applied Intelligence is the public-facing framework shell for a connected manufacturing ecosystem built around visibility, improvement, coordination, value, corrective action, and measurable execution.</p>
+
+        <div class="framework-banner chrome banner-v16">
+          <strong>Applied Intelligence Framework</strong>
+          <div>One ecosystem. Separate apps. Clear value.</div>
+        </div>
+
+        <div class="hero-actions hero-actions-v16">
+          <a class="btn primary" href="framework.html">Open the Framework <span aria-hidden="true">→</span></a>
+          <a class="btn ghost" href="ai-connect.html">See AI-Connect</a>
+        </div>
+
+        <div class="metrics metrics-v16">
+          <div class="metric"><strong>7</strong><span>Core ecosystem systems</span></div>
+          <div class="metric"><strong>1</strong><span>Parent umbrella</span></div>
+          <div class="metric"><strong>1</strong><span>Connection layer</span></div>
+          <div class="metric"><strong>24/7</strong><span>Built to move shift to value</span></div>
+        </div>
+
+        <div class="surface trace-surface-v16">
+          <h2 class="section-title">Trace to improvement.</h2>
+          <p class="section-copy">Expose the signal. Rank the friction. Route ownership. Verify completion. Clear through CIS. Retain the accountability trail.</p>
+          <div class="command-list">
+            <div class="command-pill">1. Log the issue</div>
+            <div class="command-pill">2. Surface the pattern</div>
+            <div class="command-pill">3. Route responsibility</div>
+            <div class="command-pill">4. Verify completion</div>
+            <div class="command-pill">5. Clear through AI-CIS</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="hero-center-v16">
+        <div class="hero-panel chrome compact-panel">
+          <div class="topline">
+            <h3>System overview</h3>
+            <span class="tag teal">AI-Connect</span>
+          </div>
+          <p>Connects identity, routing, permissions, resolution, handoffs, and meeting prep across real apps as connective tissue across the same ecosystem as the apps.</p>
+          <div class="chips compact-chips">
+            <span class="chip">Public framework shell</span>
+            <span class="chip">Policing-data</span>
+            <span class="chip">Same product family</span>
+          </div>
+        </div>
+
+        <div class="grid-2 grid-2-v16">
+          <div class="card">
+            <div class="topline"><h3>AI-Trace</h3><span class="tag blue">Visibility</span></div>
+            <p>Logging, patterns, dashboards, ranked friction, and operational clarity.</p>
+          </div>
+          <div class="card">
+            <div class="topline"><h3>AI-CIS</h3><span class="tag copper">Improvement</span></div>
+            <p>LIR, LRR, LRAQ, 5-onfold, and structured corrective momentum.</p>
+          </div>
+          <div class="card">
+            <div class="topline"><h3>AI-ROI</h3><span class="tag green">Value</span></div>
+            <p>Business justification, payback, and financial clarity once the work is real.</p>
+          </div>
+          <div class="card">
+            <div class="topline"><h3>AI-Case</h3><span class="tag indigo">Order</span></div>
+            <p>Portfolio-ready case studies and project storytelling after validation.</p>
+          </div>
+          <div class="card">
+            <div class="topline"><h3>AI-RMA</h3><span class="tag red">Correction</span></div>
+            <p>Return flow, failure tracing, containment, and corrective closure.</p>
+          </div>
+          <div class="card">
+            <div class="topline"><h3>Formatter</h3><span class="tag silver">Output</span></div>
+            <p>Final document cleanup and branded presentation utility.</p>
+          </div>
+        </div>
+
+        <div class="surface analytics-block">
+          <h2 class="section-title">What AI-Trace exposes</h2>
+          <p class="section-copy">Borrowed from the app’s analytics lens: the story is not just that issues exist, but that the system can rank them clearly enough to act.</p>
+          <div class="analytics-list">
+            <div class="bar-row"><span>Welding</span><div class="bar-track"><div class="bar-fill" style="width:92%"></div></div><div class="bar-val">92</div></div>
+            <div class="bar-row"><span>Laser</span><div class="bar-track"><div class="bar-fill" style="width:76%"></div></div><div class="bar-val">76</div></div>
+            <div class="bar-row"><span>Assembly</span><div class="bar-track"><div class="bar-fill" style="width:48%"></div></div><div class="bar-val">48</div></div>
+            <div class="bar-row"><span>Quality</span><div class="bar-track"><div class="bar-fill" style="width:21%"></div></div><div class="bar-val">21</div></div>
+          </div>
+        </div>
+      </div>
+
+      <aside class="hero-showcase-v16">
+        <div class="device-panel">
+          <img src="assets/home-device-showcase.png" alt="Applied Intelligence mobile and tablet showcase" />
+        </div>
+      </aside>
+    </div>
+  </section>
+
+  <section class="section section-tight-v16">
+    <div class="container anchor-strip anchor-strip-v16">
+      <div class="anchor-pill anchor-pill-icon">
+        <div class="anchor-icon-wrap"><img src="assets/logo-icon.png" alt="" /></div>
+        <div>
+          <strong>Website</strong>
+          <p>Public-facing framework shell with cleaner narrative, reading, and product story.</p>
+        </div>
+      </div>
+      <div class="anchor-pill anchor-pill-icon">
+        <div class="anchor-icon simple-icon">▣</div>
+        <div>
+          <strong>App</strong>
+          <p>Operating interface for workflows, routing, logging, routing, and live interaction.</p>
+        </div>
+      </div>
+      <div class="anchor-pill anchor-pill-icon">
+        <div class="anchor-icon simple-icon">◫</div>
+        <div>
+          <strong>Mobile</strong>
+          <p>Built to be used on the fly, anywhere, and in your pocket when the moment is happening.</p>
+        </div>
+      </div>
+      <div class="anchor-pill anchor-pill-icon founder-pill-v16">
+        <div class="anchor-icon simple-icon">◌</div>
+        <div>
+          <div class="topline">
+            <strong>About Christopher Hilton</strong>
+            <span class="tag silver">Founder</span>
+          </div>
+          <p>Automation, manufacturing engineering, statistics, troubleshooting, and production optimization driving the framework.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="section section-tight-v16">
+    <div class="container feature-bar-v16">
+      <div class="feature-chip"><img src="assets/logo-icon.png" alt="" /><div><strong>Connected ecosystem</strong><span>One framework. Separate apps. Unified by AI-Connect.</span></div></div>
+      <div class="feature-chip"><div class="feature-icon">⛓</div><div><strong>Real-time visibility</strong><span>Surface issues, rank friction, and act with clarity.</span></div></div>
+      <div class="feature-chip"><div class="feature-icon">↗</div><div><strong>Built for improvement</strong><span>Structured tools that drive measurable outcomes.</span></div></div>
+      <div class="feature-chip"><div class="feature-icon">⛨</div><div><strong>Secure by design</strong><span>Permissions, routing, and controls built-in.</span></div></div>
+      <div class="feature-chip"><div class="feature-icon">◔</div><div><strong>Anywhere access</strong><span>Web, tablet, mobile—work wherever it happens.</span></div></div>
+    </div>
+  </section>
+</main>
+
+<div class="dock-wrap">
+  <div class="container">
+    <div class="dock chrome dock-v16" data-mobile-dock>
+      <nav class="dock-nav dock-nav-v16">
+        <a class="dock-brand" href="index.html" aria-label="Applied Intelligence home"><img src="assets/logo-icon.png" alt="Applied Intelligence logo" /></a>
+        <a class="active" href="index.html">Home</a>
+        <a href="framework.html">Framework</a>
+        <a href="ai-connect.html">AI-Connect</a>
+        <a href="ai-trace.html">AI-Trace</a>
+        <a href="agents.html">Agents</a>
+        <a href="contact.html">Contact</a>
+      </nav>
+    </div>
+  </div>
+</div>
+
+<footer class="footer"><div class="container">© <span data-year></span> Applied Intelligence</div></footer>
+<script src="app.js"></script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,797 @@
+
+:root{
+  --bg:#050914;
+  --bg-deep:#04070f;
+  --bg-soft:#071120;
+  --surface:#0b1529;
+  --surface-2:#0f1b33;
+  --surface-3:#13203c;
+  --chrome-top:rgba(18,28,48,.58);
+  --chrome-bottom:rgba(12,19,36,.42);
+  --chrome-border:rgba(255,255,255,.12);
+  --text:#eef4ff;
+  --muted:#9fb2d7;
+  --muted-2:#8395b7;
+  --blue:#8fcfff;
+  --blue-2:#65aef7;
+  --teal:#6ee0d7;
+  --copper:#dca06c;
+  --green:#7bd790;
+  --red:#df7d7d;
+  --indigo:#9ca9ff;
+  --silver:#d7deea;
+  --gold:#f0c879;
+  --line:rgba(255,255,255,.08);
+  --radius:24px;
+  --radius-lg:30px;
+  --pill:999px;
+  --shadow:0 18px 48px rgba(0,0,0,.34);
+  --shadow-soft:0 10px 28px rgba(0,0,0,.24);
+  --max:1240px;
+}
+*{box-sizing:border-box}
+html{scroll-behavior:smooth; background-color:var(--bg);} 
+html,body{background-color:var(--bg);}
+body{
+  margin:0;
+  padding-top:env(safe-area-inset-top, 0px);
+  font-family:Inter,ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;
+  color:var(--text);
+  background:
+    radial-gradient(circle at 18% 8%, rgba(120,185,255,.08), transparent 20%),
+    radial-gradient(circle at 85% 18%, rgba(120,185,255,.05), transparent 22%),
+    radial-gradient(circle at 50% 80%, rgba(101,174,247,.04), transparent 20%),
+    linear-gradient(180deg,#06101f 0%, #040912 42%, #03070f 100%);
+  min-height:100vh;
+  overflow-x:hidden;
+  overscroll-behavior-y:none;
+}
+body::before{
+  content:"";
+  position:fixed; inset:0; pointer-events:none;
+  background:
+    radial-gradient(1px 1px at 12% 15%, rgba(255,255,255,.55), transparent 60%),
+    radial-gradient(1px 1px at 24% 62%, rgba(255,255,255,.28), transparent 60%),
+    radial-gradient(1px 1px at 77% 22%, rgba(255,255,255,.36), transparent 60%),
+    radial-gradient(1.2px 1.2px at 88% 74%, rgba(143,207,255,.45), transparent 60%);
+  opacity:.26;
+}
+.container{width:min(var(--max), calc(100% - 34px)); margin:0 auto;}
+.site-header{position:sticky; top:0; z-index:50; padding-top:calc(env(safe-area-inset-top, 0px) + 10px);}
+.nav{
+  min-height:74px; display:flex; align-items:center; justify-content:space-between; gap:20px;
+  border-radius:26px;
+  padding:0 16px 0 18px;
+  background:linear-gradient(180deg, var(--chrome-top), var(--chrome-bottom));
+  border:1px solid var(--chrome-border);
+  backdrop-filter:blur(22px) saturate(140%);
+  -webkit-backdrop-filter:blur(22px) saturate(140%);
+  box-shadow:0 10px 32px rgba(0,0,0,.24), inset 0 1px 0 rgba(255,255,255,.08);
+}
+.brand{color:inherit; text-decoration:none; display:flex; align-items:flex-start; min-width:320px;}
+.brand-copy strong{display:block; font-size:1.08rem; font-weight:700; letter-spacing:-.02em}
+.brand-copy span{display:block; margin-top:4px; font-size:.69rem; color:var(--muted); letter-spacing:.24em; text-transform:uppercase;}
+.nav-links{display:flex; flex-wrap:wrap; gap:10px;}
+.nav-links a{
+  color:var(--muted); text-decoration:none; font-size:.94rem; padding:10px 14px; border-radius:999px;
+  transition:background .18s ease, color .18s ease, border-color .18s ease;
+  border:1px solid transparent;
+}
+.nav-links a:hover,.nav-links a.active{
+  color:var(--text); background:rgba(255,255,255,.05); border-color:rgba(255,255,255,.08);
+}
+.hero{padding:52px 0 26px}
+.hero-grid{display:grid; grid-template-columns:1.05fr .95fr; gap:24px; align-items:start}
+.kicker{color:var(--blue); text-transform:uppercase; letter-spacing:.22em; font-size:.79rem; font-weight:700;}
+.hero h1,.page-hero h1{margin:14px 0 16px; font-size:clamp(3.45rem,6vw,6rem); line-height:.92; letter-spacing:-.06em;}
+.hero p,.page-hero p,.section-copy{color:var(--muted); font-size:1.05rem; line-height:1.7;}
+.chrome{
+  background:linear-gradient(180deg, rgba(17,27,46,.58), rgba(11,18,34,.36));
+  border:1px solid rgba(255,255,255,.10);
+  box-shadow:0 18px 48px rgba(0,0,0,.25), inset 0 1px 0 rgba(255,255,255,.08);
+  backdrop-filter:blur(18px) saturate(135%);
+}
+.surface,.hero-panel,.metric,.story-card,.dock{
+  background:linear-gradient(180deg, rgba(14,23,43,.96), rgba(8,14,27,.98));
+  border:1px solid rgba(255,255,255,.08);
+  box-shadow:var(--shadow), inset 0 1px 0 rgba(255,255,255,.03);
+}
+.hero-panel,.surface,.metric,.story-card{border-radius:24px;}
+.hero-panel{padding:20px 20px 18px; position:relative; overflow:hidden}
+.hero-panel::before,.story-card::before,.surface::before{
+  content:""; position:absolute; inset:0; pointer-events:none;
+  background:linear-gradient(135deg, rgba(255,255,255,.045), transparent 26%);
+}
+.framework-banner{border-radius:22px; padding:18px 20px; margin-top:18px;}
+.framework-banner strong{display:block; margin-bottom:6px}
+.hero-actions{display:flex; gap:14px; flex-wrap:wrap; margin-top:22px}
+.btn{display:inline-flex; align-items:center; justify-content:center; gap:10px; padding:14px 22px; border-radius:var(--pill); text-decoration:none; font-weight:700; border:1px solid rgba(255,255,255,.10); color:var(--text); background:rgba(255,255,255,.02);}
+.btn.primary{color:#07101d; background:linear-gradient(180deg, rgba(143,207,255,.96), rgba(101,174,247,.90)); box-shadow:0 0 28px rgba(101,174,247,.20);}
+.btn.ghost:hover{border-color:rgba(143,207,255,.28)}
+.metrics{display:grid; grid-template-columns:repeat(4,minmax(0,1fr)); gap:14px; margin-top:18px}
+.metric{padding:18px}
+.metric strong{display:block; font-size:1.95rem; margin-bottom:8px}
+.metric span{display:block; color:var(--muted); font-size:.92rem}
+.hero-right{display:grid; gap:18px}
+.grid-2{display:grid; grid-template-columns:1fr 1fr; gap:18px}
+.card,.story-card{padding:18px 18px 16px; position:relative; overflow:hidden}
+.card{border-radius:24px; background:linear-gradient(180deg, rgba(15,24,46,.9), rgba(9,15,29,.95)); border:1px solid rgba(255,255,255,.08); box-shadow:var(--shadow-soft), inset 0 1px 0 rgba(255,255,255,.03)}
+.card::before{content:""; position:absolute; inset:0; pointer-events:none; background:linear-gradient(135deg, rgba(255,255,255,.04), transparent 22%), linear-gradient(315deg, rgba(143,207,255,.04), transparent 18%);}
+.card h3,.story-card h3{margin:0; font-size:1.22rem}
+.card p,.story-card p{margin:12px 0 0; color:var(--muted); line-height:1.55}
+.topline{display:flex; align-items:center; justify-content:space-between; gap:10px}
+.tag{display:inline-flex; align-items:center; padding:6px 10px; border-radius:999px; border:1px solid rgba(255,255,255,.10); background:rgba(255,255,255,.03); color:var(--muted); font-size:.74rem; text-transform:uppercase; letter-spacing:.12em;}
+.tag.blue{color:#d8eeff;border-color:rgba(143,207,255,.22)}
+.tag.copper{color:#ffd9be;border-color:rgba(220,160,108,.22)}
+.tag.green{color:#e1fae6;border-color:rgba(123,215,144,.22)}
+.tag.indigo{color:#e7eaff;border-color:rgba(156,169,255,.22)}
+.tag.red{color:#ffe0e0;border-color:rgba(223,125,125,.22)}
+.tag.teal{color:#dbfffb;border-color:rgba(110,224,215,.22)}
+.tag.silver{color:#f1f5fb;border-color:rgba(215,222,234,.22)}
+.section{padding:28px 0}
+.section-title{font-size:clamp(1.95rem,3.4vw,3rem); letter-spacing:-.04em; line-height:1.02; margin:0 0 12px;}
+.cards-3{display:grid; grid-template-columns:repeat(3,minmax(0,1fr)); gap:18px}
+.split{display:grid; grid-template-columns:1fr 1fr; gap:18px}
+.analytics-block,.surface{padding:20px; position:relative}
+.analytics-list{display:grid; gap:14px; margin-top:16px}
+.bar-row{display:grid; grid-template-columns:120px 1fr 28px; gap:12px; align-items:center}
+.bar-row span{color:var(--text)}
+.bar-track{position:relative; height:12px; border-radius:999px; overflow:hidden; background:rgba(255,255,255,.06); border:1px solid rgba(255,255,255,.05);}
+.bar-fill{position:absolute; inset:0 auto 0 0; border-radius:999px; background:linear-gradient(90deg, rgba(143,207,255,.96), rgba(240,200,121,.88));}
+.bar-val{color:var(--muted); text-align:right; font-size:.92rem}
+.command-list{display:grid; gap:14px; margin-top:16px}
+.command-pill{min-height:62px; display:flex; align-items:center; padding:0 18px; border-radius:999px; background:linear-gradient(180deg, rgba(16,28,52,.82), rgba(8,15,30,.94)); border:1px solid rgba(255,255,255,.08); color:var(--text);}
+.page-hero{padding:46px 0 16px}
+.page-grid{display:grid; grid-template-columns:1fr 1fr; gap:18px}
+.story-grid{display:grid; grid-template-columns:repeat(3,minmax(0,1fr)); gap:18px; margin-top:18px}
+.story-card{border-radius:24px;}
+.anchor-strip{display:grid; grid-template-columns:repeat(3,minmax(0,1fr)); gap:18px}
+.anchor-pill{padding:18px 18px 16px; border-radius:22px; background:linear-gradient(180deg, rgba(10,17,32,.78), rgba(9,14,26,.96)); border:1px solid rgba(255,255,255,.07)}
+.anchor-pill strong{display:block; font-size:1rem; margin-bottom:8px}
+.anchor-pill p{margin:0; color:var(--muted); line-height:1.55}
+.founder-strip{display:grid; grid-template-columns:1.2fr auto; gap:22px; align-items:end; padding:22px 24px; border-radius:24px}
+.founder-title{font-size:clamp(1.55rem,3vw,2.35rem); line-height:1.04; letter-spacing:-.04em; margin:10px 0 12px}
+.small-kicker{color:var(--muted); font-size:.88rem; text-transform:uppercase; letter-spacing:.12em}
+.chips{display:flex; flex-wrap:wrap; gap:10px; margin-top:16px}
+.chip{display:inline-flex; align-items:center; padding:10px 14px; border-radius:999px; border:1px solid rgba(255,255,255,.08); background:rgba(255,255,255,.03); color:var(--muted); font-size:.88rem;}
+.notice{color:var(--blue); font-weight:700}
+.dock-wrap{padding:18px 0 16px}
+.dock{position:sticky; bottom:14px; z-index:30; border-radius:30px; padding:12px; max-width:1040px; margin:0 auto; background:linear-gradient(180deg, rgba(20,31,53,.58), rgba(12,19,34,.34)); border:1px solid rgba(255,255,255,.12); backdrop-filter:blur(22px) saturate(145%); -webkit-backdrop-filter:blur(22px) saturate(145%); box-shadow:0 20px 44px rgba(0,0,0,.24), inset 0 1px 0 rgba(255,255,255,.08);}
+.dock-nav{display:grid; grid-template-columns:repeat(6,minmax(0,1fr)); gap:12px}
+.dock-nav a{display:flex; align-items:center; justify-content:center; min-height:68px; text-decoration:none; color:var(--text); font-weight:700; border-radius:24px; background:linear-gradient(180deg, rgba(255,255,255,.06), rgba(255,255,255,.02)); border:1px solid rgba(255,255,255,.10); box-shadow:inset 0 1px 0 rgba(255,255,255,.05);}
+.dock-nav a:hover,.dock-nav a.active{background:linear-gradient(180deg, rgba(88,116,171,.34), rgba(22,36,64,.54));}
+.dock{transition:transform .26s ease, opacity .26s ease, box-shadow .26s ease;}
+
+.dock.is-hidden{transform:translateY(calc(100% + 22px)); opacity:0; pointer-events:none;}
+.footer{padding:18px 0 42px; color:var(--muted); font-size:.92rem}
+.section-rail{display:flex; flex-wrap:wrap; gap:10px; margin-top:18px}
+.section-rail a,.section-rail span{padding:10px 14px; border-radius:999px; color:var(--muted); border:1px solid rgba(255,255,255,.08); background:rgba(255,255,255,.02); text-decoration:none; font-size:.88rem}
+.section-rail a:hover{color:var(--text); border-color:rgba(143,207,255,.20)}
+@media (max-width:1160px){
+  .hero-grid,.cards-3,.grid-2,.split,.page-grid,.story-grid,.anchor-strip{grid-template-columns:1fr}
+  .metrics{grid-template-columns:repeat(2,minmax(0,1fr))}
+  .founder-strip{grid-template-columns:1fr}
+}
+@media (max-width:760px){
+  .container{width:min(var(--max), calc(100% - 22px))}
+  .site-header{padding-top:8px}
+  .nav{min-height:68px; align-items:flex-start; padding:12px 14px}
+  .nav-links{gap:8px}
+  .nav-links a{padding:9px 12px}
+  .hero h1,.page-hero h1{font-size:clamp(2.7rem,11vw,4.6rem)}
+  .metrics{grid-template-columns:1fr}
+  .dock-nav{grid-template-columns:repeat(4,minmax(0,1fr))}
+  .dock-nav a{min-height:60px}
+  .dock-nav a.dock-secondary{display:none}
+}
+
+
+
+@media (min-width:761px) and (max-width:1180px){
+  .dock{max-width:1120px; padding:14px}
+  .dock-nav{grid-template-columns:repeat(6,minmax(0,1fr)); gap:10px}
+  .dock-nav a{min-height:64px; padding:0 14px}
+}
+
+/* V11 refinements */
+.compact-panel{padding-bottom:16px}
+.compact-panel p{margin-bottom:10px}
+.compact-chips{margin-top:14px}
+.page-grid{align-items:start}
+.about-hero h1{max-width:9ch}
+@media (min-width: 1161px){
+  .about-hero .hero-panel{min-height:auto}
+}
+
+
+/* V12 mobile refinement */
+html, body { -webkit-text-size-adjust: 100%; }
+.hero h1,
+.page-hero h1,
+.section-title,
+.founder-title {
+  text-wrap: balance;
+}
+.hero p,
+.page-hero p,
+.section-copy {
+  max-width: 36rem;
+}
+.nav-toggle{
+  display:none;
+  width:48px;
+  height:48px;
+  border-radius:18px;
+  border:1px solid rgba(255,255,255,.10);
+  background:linear-gradient(180deg, rgba(255,255,255,.06), rgba(255,255,255,.02));
+  box-shadow:inset 0 1px 0 rgba(255,255,255,.05);
+  align-items:center;
+  justify-content:center;
+  flex-direction:column;
+  gap:5px;
+  color:var(--text);
+}
+.nav-toggle span{
+  width:18px;
+  height:2px;
+  border-radius:999px;
+  background:rgba(238,244,255,.92);
+  display:block;
+  transition:transform .18s ease, opacity .18s ease;
+}
+.nav-toggle[aria-expanded="true"] span:nth-child(1){transform:translateY(7px) rotate(45deg);}
+.nav-toggle[aria-expanded="true"] span:nth-child(2){opacity:0;}
+.nav-toggle[aria-expanded="true"] span:nth-child(3){transform:translateY(-7px) rotate(-45deg);}
+.cards-3 > .card,
+.story-grid > .story-card,
+.split > .surface,
+.anchor-strip > .anchor-pill,
+.grid-2 > .card {
+  min-width: 0;
+}
+@media (max-width: 900px){
+  .container{width:min(var(--max), calc(100% - 26px));}
+  .site-header{padding-top:8px;}
+  .nav{
+    min-height:auto;
+    padding:12px 14px;
+    gap:14px;
+  }
+  .brand{min-width:0; flex:1;}
+  .brand-copy strong{font-size:1.02rem;}
+  .brand-copy span{font-size:.65rem; letter-spacing:.18em;}
+  .hero{padding:40px 0 20px;}
+  .page-hero{padding:34px 0 10px;}
+  .section{padding:22px 0;}
+  .hero-grid,
+  .page-grid{
+    gap:16px;
+  }
+  .hero-panel,
+  .surface,
+  .story-card,
+  .card,
+  .metric,
+  .anchor-pill,
+  .framework-banner,
+  .founder-strip{
+    padding:18px;
+    border-radius:22px;
+  }
+  .cards-3,
+  .story-grid,
+  .split,
+  .grid-2,
+  .anchor-strip{
+    gap:14px;
+  }
+  .command-list,
+  .analytics-list{
+    gap:12px;
+  }
+  .command-pill{
+    min-height:56px;
+    padding:0 16px;
+  }
+}
+@media (max-width: 760px){
+  body.nav-open{overflow:hidden;}
+  .container{width:min(var(--max), calc(100% - 20px));}
+  .nav{
+    position:relative;
+    align-items:center;
+    flex-wrap:wrap;
+    border-radius:24px;
+    padding:12px;
+  }
+  .nav-toggle{display:inline-flex;}
+  .nav-links{
+    display:none;
+    width:100%;
+    padding-top:6px;
+    gap:8px;
+  }
+  .nav-links.is-open{
+    display:grid;
+    grid-template-columns:1fr 1fr;
+  }
+  .nav-links a{
+    width:100%;
+    min-height:48px;
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    padding:10px 12px;
+    border-radius:16px;
+    background:rgba(255,255,255,.03);
+    border:1px solid rgba(255,255,255,.06);
+  }
+  .hero,
+  .page-hero{
+    padding-top:28px;
+  }
+  .hero h1,
+  .page-hero h1{
+    font-size:clamp(2.45rem, 10vw, 4.1rem);
+    line-height:.96;
+    letter-spacing:-.055em;
+    margin:12px 0 12px;
+    max-width:10.5ch;
+  }
+  .hero p,
+  .page-hero p,
+  .section-copy{
+    font-size:.98rem;
+    line-height:1.62;
+  }
+  .kicker{
+    font-size:.72rem;
+    letter-spacing:.18em;
+  }
+  .hero-actions{
+    gap:10px;
+    margin-top:18px;
+  }
+  .hero-actions .btn{
+    flex:1 1 calc(50% - 5px);
+    min-height:50px;
+    padding:13px 16px;
+  }
+  .metrics{
+    grid-template-columns:repeat(2,minmax(0,1fr));
+    gap:10px;
+    margin-top:14px;
+  }
+  .metric{
+    padding:16px 14px;
+  }
+  .metric strong{
+    font-size:1.6rem;
+    margin-bottom:6px;
+  }
+  .hero-right{gap:14px;}
+  .cards-3,
+  .story-grid,
+  .split,
+  .grid-2,
+  .page-grid,
+  .anchor-strip{
+    grid-template-columns:1fr;
+    gap:12px;
+  }
+  .card,
+  .surface,
+  .story-card,
+  .hero-panel,
+  .anchor-pill,
+  .framework-banner,
+  .founder-strip{
+    padding:16px;
+    border-radius:20px;
+  }
+  .topline{
+    align-items:flex-start;
+    gap:8px;
+  }
+  .topline h3{
+    font-size:1.08rem;
+    line-height:1.15;
+  }
+  .tag{
+    font-size:.68rem;
+    letter-spacing:.1em;
+    padding:6px 9px;
+  }
+  .chips{
+    gap:8px;
+    margin-top:14px;
+  }
+  .chip{
+    padding:8px 12px;
+    font-size:.82rem;
+  }
+  .command-list{
+    gap:10px;
+    margin-top:14px;
+  }
+  .command-pill{
+    min-height:52px;
+    padding:0 14px;
+    font-size:.95rem;
+    border-radius:18px;
+  }
+  .analytics-list{
+    gap:12px;
+    margin-top:14px;
+  }
+  .bar-row{
+    grid-template-columns:84px 1fr 28px;
+    gap:8px;
+  }
+  .bar-row span,
+  .bar-val{
+    font-size:.88rem;
+  }
+  .section-rail{
+    gap:8px;
+    margin-top:14px;
+  }
+  .section-rail a,
+  .section-rail span{
+    padding:8px 12px;
+    font-size:.82rem;
+  }
+  .founder-strip{
+    align-items:start;
+  }
+  .founder-title{
+    font-size:clamp(1.45rem, 7vw, 2.2rem);
+    line-height:1.06;
+    margin:10px 0;
+  }
+  .about-hero h1{
+    max-width:7.5ch;
+  }
+  .about-hero .hero-panel p{
+    margin-top:10px;
+  }
+  .dock-wrap{
+    padding:12px 0 calc(env(safe-area-inset-bottom, 0px) + 10px);
+  }
+  .dock{
+    padding:10px;
+    border-radius:26px;
+    max-width:none;
+    width:calc(100% - 8px);
+    margin:0 auto;
+  }
+  .dock::before, .dock::after{content:""; position:absolute; top:12px; bottom:12px; width:14px; pointer-events:none; z-index:2;}
+  .dock::before{left:10px; background:linear-gradient(90deg, rgba(12,19,34,.9), rgba(12,19,34,0)); border-radius:18px 0 0 18px;}
+  .dock::after{right:10px; background:linear-gradient(270deg, rgba(12,19,34,.9), rgba(12,19,34,0)); border-radius:0 18px 18px 0;}
+  .dock-nav{
+    display:grid;
+    grid-template-columns:repeat(4,minmax(0,1fr));
+    gap:10px;
+    overflow:visible;
+    padding-bottom:0;
+  }
+  .dock-nav a{
+    flex:initial;
+    min-width:0;
+    min-height:54px;
+    padding:0 10px;
+    border-radius:18px;
+    font-size:.9rem;
+    white-space:nowrap;
+  }
+  .footer{
+    padding:14px 0 28px;
+  }
+}
+@media (max-width: 520px){
+  .hero h1,
+  .page-hero h1{
+    font-size:clamp(2.15rem, 10vw, 3.4rem);
+    max-width:9.2ch;
+  }
+  .hero-actions .btn{
+    flex:1 1 100%;
+  }
+  .metrics{
+    grid-template-columns:1fr;
+  }
+  .nav-links.is-open{
+    grid-template-columns:1fr;
+  }
+  .brand-copy strong{
+    font-size:.98rem;
+  }
+  .brand-copy span{
+    font-size:.62rem;
+    letter-spacing:.14em;
+  }
+}
+
+
+
+/* V16 homepage refresh */
+.brand-v16{
+  align-items:center;
+  gap:14px;
+  min-width:0;
+}
+.brand-icon{
+  width:56px;
+  height:56px;
+  object-fit:cover;
+  border-radius:18px;
+  box-shadow:0 0 0 1px rgba(255,255,255,.10), 0 0 22px rgba(69,120,255,.28);
+  flex:0 0 auto;
+}
+.nav-v16{
+  gap:24px;
+  padding:14px 18px;
+}
+.nav-links-v16{
+  margin-left:auto;
+  align-items:center;
+}
+.nav-links-v16 a{
+  min-height:48px;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  padding:10px 20px;
+  font-weight:600;
+}
+.nav-links-v16 a.active{
+  background:linear-gradient(180deg, rgba(40,87,214,.74), rgba(18,39,108,.82));
+  border-color:rgba(111,161,255,.36);
+  box-shadow:0 0 0 1px rgba(123,175,255,.10), 0 0 18px rgba(67,124,255,.28), inset 0 1px 0 rgba(255,255,255,.12);
+}
+
+.hero-v16{
+  padding:18px 0 12px;
+}
+.hero-layout-v16{
+  display:grid;
+  grid-template-columns:minmax(0, 1.02fr) minmax(0, .9fr) minmax(360px, .82fr);
+  gap:22px;
+  align-items:start;
+}
+.hero-left-v16,
+.hero-center-v16,
+.hero-showcase-v16{
+  min-width:0;
+}
+.banner-v16{
+  min-height:116px;
+  display:flex;
+  flex-direction:column;
+  justify-content:center;
+}
+.metrics-v16{
+  margin-top:16px;
+}
+.trace-surface-v16{
+  margin-top:16px;
+}
+.grid-2-v16{
+  margin-top:18px;
+}
+.hero-showcase-v16{
+  position:sticky;
+  top:104px;
+}
+.device-panel{
+  position:relative;
+  border-radius:30px;
+  overflow:hidden;
+  background:linear-gradient(180deg, rgba(9,18,36,.98), rgba(4,10,22,.98));
+  border:1px solid rgba(255,255,255,.10);
+  box-shadow:0 24px 60px rgba(0,0,0,.30), 0 0 40px rgba(41,98,255,.10), inset 0 1px 0 rgba(255,255,255,.06);
+}
+.device-panel::before{
+  content:"";
+  position:absolute;
+  inset:0;
+  pointer-events:none;
+  background:radial-gradient(circle at 50% 0%, rgba(86,133,255,.18), transparent 36%), linear-gradient(135deg, rgba(255,255,255,.04), transparent 28%);
+}
+.device-panel img{
+  display:block;
+  width:100%;
+  height:auto;
+}
+
+.section-tight-v16{
+  padding-top:10px;
+}
+.anchor-strip-v16{
+  grid-template-columns:repeat(4, minmax(0, 1fr));
+}
+.anchor-pill-icon{
+  display:flex;
+  align-items:flex-start;
+  gap:16px;
+  min-height:156px;
+}
+.anchor-icon-wrap,
+.anchor-icon{
+  width:52px;
+  height:52px;
+  border-radius:18px;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  background:linear-gradient(180deg, rgba(19,34,67,.95), rgba(8,16,31,.98));
+  border:1px solid rgba(255,255,255,.10);
+  box-shadow:0 0 24px rgba(59,112,255,.16), inset 0 1px 0 rgba(255,255,255,.05);
+  flex:0 0 auto;
+}
+.anchor-icon-wrap img{
+  width:38px;
+  height:38px;
+  object-fit:contain;
+}
+.simple-icon{
+  color:#a8ccff;
+  font-size:1.5rem;
+  font-weight:700;
+}
+.founder-pill-v16 strong{
+  font-size:1rem;
+}
+
+.feature-bar-v16{
+  display:grid;
+  grid-template-columns:repeat(5, minmax(0, 1fr));
+  gap:0;
+  border-radius:28px;
+  overflow:hidden;
+  background:linear-gradient(180deg, rgba(11,21,41,.94), rgba(7,14,28,.98));
+  border:1px solid rgba(255,255,255,.09);
+  box-shadow:0 18px 48px rgba(0,0,0,.26), inset 0 1px 0 rgba(255,255,255,.04);
+}
+.feature-chip{
+  min-width:0;
+  display:flex;
+  gap:14px;
+  align-items:flex-start;
+  padding:20px 18px;
+  position:relative;
+}
+.feature-chip + .feature-chip::before{
+  content:"";
+  position:absolute;
+  left:0;
+  top:18px;
+  bottom:18px;
+  width:1px;
+  background:rgba(255,255,255,.10);
+}
+.feature-chip img,
+.feature-icon{
+  width:50px;
+  height:50px;
+  border-radius:18px;
+  object-fit:cover;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  background:linear-gradient(180deg, rgba(19,34,67,.95), rgba(8,16,31,.98));
+  border:1px solid rgba(255,255,255,.10);
+  box-shadow:0 0 24px rgba(59,112,255,.16), inset 0 1px 0 rgba(255,255,255,.05);
+  color:#a8ccff;
+  font-size:1.3rem;
+  font-weight:700;
+  flex:0 0 auto;
+}
+.feature-chip strong{
+  display:block;
+  font-size:1.04rem;
+  margin-bottom:5px;
+}
+.feature-chip span{
+  display:block;
+  color:var(--muted);
+  line-height:1.45;
+  font-size:.92rem;
+}
+
+.dock-v16{
+  max-width:1240px;
+}
+.dock-nav-v16{
+  grid-template-columns:74px repeat(6, minmax(0, 1fr));
+}
+.dock-brand{
+  padding:0 !important;
+}
+.dock-brand img{
+  width:52px;
+  height:52px;
+  object-fit:cover;
+  border-radius:18px;
+}
+
+@media (max-width: 1380px){
+  .hero-layout-v16{
+    grid-template-columns:minmax(0, 1fr) minmax(0, 1fr);
+  }
+  .hero-showcase-v16{
+    position:static;
+    grid-column:1 / -1;
+  }
+  .device-panel{
+    max-width:760px;
+    margin:0 auto;
+  }
+  .anchor-strip-v16{
+    grid-template-columns:repeat(2, minmax(0, 1fr));
+  }
+  .feature-bar-v16{
+    grid-template-columns:repeat(2, minmax(0, 1fr));
+  }
+}
+@media (max-width: 900px){
+  .brand-icon{
+    width:48px;
+    height:48px;
+    border-radius:16px;
+  }
+  .hero-layout-v16{
+    grid-template-columns:1fr;
+    gap:16px;
+  }
+  .hero-showcase-v16{
+    order:2;
+  }
+  .hero-center-v16{
+    order:3;
+  }
+  .anchor-strip-v16{
+    grid-template-columns:1fr;
+  }
+  .feature-bar-v16{
+    grid-template-columns:1fr;
+  }
+  .feature-chip + .feature-chip::before{
+    top:0;
+    left:18px;
+    right:18px;
+    width:auto;
+    height:1px;
+  }
+  .dock-nav-v16{
+    grid-template-columns:repeat(4, minmax(0, 1fr));
+  }
+  .dock-nav-v16 .dock-brand{
+    display:none;
+  }
+}
+@media (max-width: 760px){
+  .nav-v16{
+    padding:12px;
+  }
+  .nav-links-v16{
+    margin-left:0;
+  }
+  .nav-links-v16.is-open{
+    grid-template-columns:1fr 1fr;
+  }
+  .hero-v16{
+    padding-top:14px;
+  }
+  .anchor-pill-icon{
+    min-height:auto;
+  }
+}
+@media (max-width: 520px){
+  .nav-links-v16.is-open{
+    grid-template-columns:1fr;
+  }
+  .feature-chip{
+    padding:18px 16px;
+  }
+}


### PR DESCRIPTION
### Motivation

- Provide a public-facing framework shell and informational site for the Applied Intelligence product family.  
- Create consistent, responsive UI and visual language shared across the homepage and per-agent pages.  
- Implement small client-side behaviors for navigation, dock visibility, and automatic year display.

### Description

- Add new HTML pages: `index.html`, `framework.html`, `ai-connect.html`, `ai-trace.html`, `agents.html`, `about.html`, and `contact.html` to present the framework and agents.  
- Ship a comprehensive `style.css` that defines the theme, layout, responsive rules, components, and V16 homepage refinements.  
- Add `app.js` to populate `data-year`, toggle the mobile navigation (`data-nav-toggle` / `data-nav-links`), and control the mobile dock show/hide behavior on scroll (`data-mobile-dock`).  
- Wire the pages to use the shared stylesheet and script and include consistent navigation, dock, and hero/section components across the site.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee204ef0788323890f272c90efab5f)