### PR TITLE
V16 homepage visual refit toward dark framework dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,95 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Applied Intelligence — Standardize to Optimize</title>
+    <meta
+      name="description"
+      content="Applied Intelligence is the public-facing framework shell for a connected manufacturing ecosystem built around visibility, improvement, coordination, value, corrective action, and measurable execution."
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="page-shell">
+      <header class="top-nav glass">
+        <div class="brand">
+          <span class="brand-dot" aria-hidden="true"></span>
+          <div>
+            <p class="brand-name">Applied Intelligence</p>
+            <p class="brand-line">Applied Intelligence Framework</p>
+          </div>
+        </div>
+        <nav aria-label="Primary">
+          <ul>
+            <li><a class="is-active" href="/">Home</a></li>
+            <li><a href="/framework">Framework</a></li>
+            <li><a href="/agents">Agents</a></li>
+            <li><a href="/ai-connect">AI-Connect</a></li>
+            <li><a href="/ai-trace">AI-Trace</a></li>
+            <li><a href="/about">About</a></li>
+            <li><a href="/contact">Contact</a></li>
+          </ul>
+        </nav>
+      </header>
+
+      <main>
+        <section class="hero grid-two">
+          <div class="panel glass hero-copy">
+            <p class="eyebrow">Public Framework Shell</p>
+            <h1>Standardize to Optimize.</h1>
+            <p>
+              Applied Intelligence is the public-facing framework shell for a connected manufacturing ecosystem
+              built around visibility, improvement, coordination, value, corrective action, and measurable
+              execution.
+            </p>
+            <p class="anchor">Built from the floor up.</p>
+          </div>
+
+          <aside class="panel glass showcase" aria-label="System showcase">
+            <h2>Website + App Separation</h2>
+            <p>
+              This website presents framework direction and system structure. The app runtime remains separate as
+              the operating interface for execution.
+            </p>
+            <div class="device-slot" role="img" aria-label="Approved app showcase asset slot">
+              <span>Approved device/app visual slot</span>
+            </div>
+          </aside>
+        </section>
+
+        <section class="system-overview panel glass">
+          <h2>System Overview</h2>
+          <div class="overview-grid">
+            <article>
+              <h3>Visibility</h3>
+              <p>Expose process reality and recurring loss patterns before they become accepted normal.</p>
+            </article>
+            <article>
+              <h3>Improvement</h3>
+              <p>Convert root causes into practical corrective action that protects flow and quality.</p>
+            </article>
+            <article>
+              <h3>Coordination</h3>
+              <p>Route the right information to the right people for measurable execution and accountability.</p>
+            </article>
+          </div>
+        </section>
+
+        <section class="agents-grid" aria-label="Agent and system cards">
+          <article class="panel glass"><h3>AI-Trace</h3><p>Analytics and visibility for hidden cost and repeat issues.</p></article>
+          <article class="panel glass"><h3>AI-CIS</h3><p>Continuous improvement and corrective action discipline.</p></article>
+          <article class="panel glass"><h3>AI-ROI</h3><p>Financial validation for improvement and equipment decisions.</p></article>
+          <article class="panel glass"><h3>AI-Connect</h3><p>Coordination, routing, and communication readiness.</p></article>
+        </section>
+      </main>
+
+      <nav class="bottom-dock glass" aria-label="Quick navigation">
+        <a class="is-active" href="/">Home</a>
+        <a href="/framework">Framework</a>
+        <a href="/agents">Agents</a>
+        <a href="/contact">Contact</a>
+      </nav>
+    </div>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,93 @@
+:root {
+  --bg: #050913;
+  --bg-soft: #0b1324;
+  --glass: rgba(13, 24, 45, 0.62);
+  --border: rgba(155, 198, 255, 0.18);
+  --text: #e7eefc;
+  --text-soft: #9fb0cf;
+  --blue: #5da4ff;
+  --radius: 22px;
+}
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: radial-gradient(circle at 15% 10%, #112140 0%, var(--bg) 45%), var(--bg);
+  color: var(--text);
+}
+
+.page-shell { max-width: 1280px; margin: 0 auto; padding: 1rem 1rem 6rem; }
+.glass {
+  background: var(--glass);
+  border: 1px solid var(--border);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  box-shadow: 0 10px 40px rgba(10, 29, 66, 0.45);
+}
+.panel { border-radius: var(--radius); padding: 1.4rem; }
+
+.top-nav {
+  border-radius: 18px;
+  padding: .7rem 1rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  position: sticky;
+  top: .75rem;
+  z-index: 50;
+}
+.brand { display:flex; align-items:center; gap:.65rem; }
+.brand-dot {
+  width: 12px; height: 12px; border-radius: 999px; background: var(--blue);
+  box-shadow: 0 0 20px rgba(93,164,255,.8);
+}
+.brand-name { margin:0; font-weight:600; }
+.brand-line { margin:0; color:var(--text-soft); font-size:.75rem; }
+.top-nav ul { list-style:none; display:flex; gap:.25rem; margin:0; padding:0; flex-wrap: wrap; }
+.top-nav a, .bottom-dock a {
+  color: var(--text-soft); text-decoration:none; padding:.5rem .8rem; border-radius: 999px; font-size:.88rem;
+}
+.top-nav a.is-active, .bottom-dock a.is-active {
+  color:#fff; background: rgba(93,164,255,.2); box-shadow: inset 0 0 0 1px rgba(130,188,255,.6), 0 0 20px rgba(93,164,255,.35);
+}
+
+main { margin-top: 1.25rem; display:grid; gap: 1rem; }
+.grid-two { display:grid; grid-template-columns: 1.35fr .9fr; gap:1rem; }
+.hero-copy h1 { font-size: clamp(2rem, 5vw, 3.8rem); margin:.3rem 0 .8rem; line-height: 1.05; }
+.hero-copy p { color:var(--text-soft); line-height:1.55; margin:.5rem 0; }
+.hero-copy .eyebrow { text-transform: uppercase; letter-spacing: .1em; font-size:.74rem; color:#c0d6ff; }
+.hero-copy .anchor { color: #d6e5ff; font-weight: 550; }
+.showcase h2, .system-overview h2 { margin-top:0; }
+.device-slot {
+  margin-top: 1rem; min-height: 220px; border-radius: 18px; border:1px dashed rgba(130,188,255,.5);
+  display:grid; place-items:center; color:var(--text-soft);
+  background: linear-gradient(180deg, rgba(93,164,255,.1), rgba(10,19,34,.4));
+}
+
+.overview-grid, .agents-grid { display:grid; gap: .8rem; grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.agents-grid { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+.agents-grid h3, .overview-grid h3 { margin:0 0 .5rem; }
+.agents-grid p, .overview-grid p { margin:0; color:var(--text-soft); }
+
+.bottom-dock {
+  position: fixed;
+  bottom: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: .4rem;
+  border-radius: 999px;
+  display:flex;
+  gap:.3rem;
+}
+
+@media (max-width: 1000px) {
+  .grid-two, .agents-grid, .overview-grid { grid-template-columns: 1fr 1fr; }
+}
+@media (max-width: 760px) {
+  .top-nav { position: static; }
+  .grid-two, .agents-grid, .overview-grid { grid-template-columns: 1fr; }
+  .bottom-dock { width: calc(100% - 1.5rem); justify-content: space-around; }
+  .top-nav nav { width:100%; }
+}


### PR DESCRIPTION
### Motivation
- Move the live homepage visual language toward the V16 dark navy / premium dashboard reference while preserving the existing site structure and route intent. 
- Provide a focused, reviewable homepage-only change that strengthens hero hierarchy, top glass navigation, system/agent cards, right-side showcase slot, and a bottom dock navigation without altering deployment or runtime logic.

### Description
- Added a static homepage entry `index.html` implementing the hero headline `Standardize to Optimize.` with supporting framework-shell positioning and website/app separation language. 
- Added `styles.css` containing the homepage visual system with a dark navy background, blue-glass panels, glowing active nav state, rounded premium cards, device showcase slot, and responsive breakpoints for mobile. 
- Preserved route links (`/framework`, `/agents`, `/ai-connect`, `/ai-trace`, `/about`, `/contact`) and avoided adding or transforming image assets by providing an approved asset slot placeholder. 
- Scoped changes to only the homepage visual shell and did not modify deployment configuration, app runtime logic, or existing pages.

### Testing
- Ran `test -f package.json && npm run build || echo 'No package.json; skipped npm build'`, which returned `No package.json; skipped npm build` (no build system detected).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3572ae8f88323a2fdfd9b98c6fc4b)