### PR TITLE
Replace placeholder pages with real content and refactor stylesheet

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Applied Intelligence | About</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="container nav-wrap">
+        <a class="brand" href="index.html">Applied Intelligence</a>
+        <nav aria-label="Primary" class="nav-links">
+          <a href="framework.html">Framework</a>
+          <a href="ai-connect.html">AI-Connect</a>
+          <a href="ai-trace.html">AI-Trace</a>
+          <a href="agents.html">Agents</a>
+          <a href="about.html">About</a>
+          <a href="contact.html">Contact</a>
+        </nav>
+      </div>
+    </header>
+    <main class="container">
+      <section class="page-hero">
+        <p class="eyebrow">Applied Intelligence</p>
+        <h1>About</h1>
+        <p class="lead">Applied Intelligence exists to provide structured, practical systems that help organizations standardize workflows and optimize outcomes.</p>
+      </section>
+      <section class="section"><article class="card"><h3>Positioning</h3><p>Applied Intelligence Framework. Built from the floor up.</p></article></section>
+    </main>
+    <footer class="site-footer">
+      <div class="container"><p>Applied Intelligence — Standardize to Optimize.</p></div>
+    </footer>
+  </body>
+</html>

--- a/agents.html
+++ b/agents.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Applied Intelligence | Agents</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="container nav-wrap">
+        <a class="brand" href="index.html">Applied Intelligence</a>
+        <nav aria-label="Primary" class="nav-links">
+          <a href="framework.html">Framework</a>
+          <a href="ai-connect.html">AI-Connect</a>
+          <a href="ai-trace.html">AI-Trace</a>
+          <a href="agents.html">Agents</a>
+          <a href="about.html">About</a>
+          <a href="contact.html">Contact</a>
+        </nav>
+      </div>
+    </header>
+    <main class="container">
+      <section class="page-hero">
+        <p class="eyebrow">Applied Intelligence</p>
+        <h1>Agents</h1>
+        <p class="lead">Agents are separated by role to keep responsibilities clear while operating inside one coordinated ecosystem.</p>
+      </section>
+      <section class="section">
+        <div class="grid three-up">
+          <article class="card"><h3>Website Agent</h3><p>Owns public presentation and framework communication.</p></article>
+          <article class="card"><h3>App Agent</h3><p>Owns runtime behavior, execution spine, and application shell operations.</p></article>
+          <article class="card"><h3>Source Agent</h3><p>Maintains shared source-of-truth bundles and alignment policies.</p></article>
+        </div>
+      </section>
+    </main>
+    <footer class="site-footer">
+      <div class="container"><p>Applied Intelligence — Standardize to Optimize.</p></div>
+    </footer>
+  </body>
+</html>

--- a/ai-connect.html
+++ b/ai-connect.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Applied Intelligence | Ai-connect</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="container nav-wrap">
+        <a class="brand" href="index.html">Applied Intelligence</a>
+        <nav aria-label="Primary" class="nav-links">
+          <a href="framework.html">Framework</a>
+          <a href="ai-connect.html">AI-Connect</a>
+          <a href="ai-trace.html">AI-Trace</a>
+          <a href="agents.html">Agents</a>
+          <a href="about.html">About</a>
+          <a href="contact.html">Contact</a>
+        </nav>
+      </div>
+    </header>
+    <main class="container">
+      <section class="page-hero">
+        <p class="eyebrow">Applied Intelligence</p>
+        <h1>Ai-connect</h1>
+        <p class="lead">AI-Connect focuses on structured connection layers between users, workflows, and intelligence services while preserving clear operational boundaries.</p>
+      </section>
+      <section class="section"><article class="card"><h3>Website Role</h3><p>This page presents the product intent and value. Native runtime execution belongs to the dedicated application repository.</p></article></section>
+    </main>
+    <footer class="site-footer">
+      <div class="container"><p>Applied Intelligence — Standardize to Optimize.</p></div>
+    </footer>
+  </body>
+</html>

--- a/ai-trace.html
+++ b/ai-trace.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Applied Intelligence | Ai-trace</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="container nav-wrap">
+        <a class="brand" href="index.html">Applied Intelligence</a>
+        <nav aria-label="Primary" class="nav-links">
+          <a href="framework.html">Framework</a>
+          <a href="ai-connect.html">AI-Connect</a>
+          <a href="ai-trace.html">AI-Trace</a>
+          <a href="agents.html">Agents</a>
+          <a href="about.html">About</a>
+          <a href="contact.html">Contact</a>
+        </nav>
+      </div>
+    </header>
+    <main class="container">
+      <section class="page-hero">
+        <p class="eyebrow">Applied Intelligence</p>
+        <h1>Ai-trace</h1>
+        <p class="lead">AI-Trace emphasizes visibility, traceability, and assurance so decisions and execution paths remain auditable and improvable.</p>
+      </section>
+      <section class="section"><article class="card"><h3>Trace Discipline</h3><p>From signals to outcomes, trace patterns support accountability and continuous learning in the ecosystem.</p></article></section>
+    </main>
+    <footer class="site-footer">
+      <div class="container"><p>Applied Intelligence — Standardize to Optimize.</p></div>
+    </footer>
+  </body>
+</html>

--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Applied Intelligence | Contact</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="container nav-wrap">
+        <a class="brand" href="index.html">Applied Intelligence</a>
+        <nav aria-label="Primary" class="nav-links">
+          <a href="framework.html">Framework</a>
+          <a href="ai-connect.html">AI-Connect</a>
+          <a href="ai-trace.html">AI-Trace</a>
+          <a href="agents.html">Agents</a>
+          <a href="about.html">About</a>
+          <a href="contact.html">Contact</a>
+        </nav>
+      </div>
+    </header>
+    <main class="container">
+      <section class="page-hero">
+        <p class="eyebrow">Applied Intelligence</p>
+        <h1>Contact</h1>
+        <p class="lead">Contact Applied Intelligence for framework alignment, ecosystem collaboration, and website-level inquiries.</p>
+      </section>
+      <section class="section"><article class="card"><h3>Contact Path</h3><p>Email: hello@appliedintelligence.dev<br />Response focus: framework, ecosystem scope, and public website direction.</p></article></section>
+    </main>
+    <footer class="site-footer">
+      <div class="container"><p>Applied Intelligence — Standardize to Optimize.</p></div>
+    </footer>
+  </body>
+</html>

--- a/framework.html
+++ b/framework.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Applied Intelligence | Framework</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="container nav-wrap">
+        <a class="brand" href="index.html">Applied Intelligence</a>
+        <nav aria-label="Primary" class="nav-links">
+          <a href="framework.html">Framework</a>
+          <a href="ai-connect.html">AI-Connect</a>
+          <a href="ai-trace.html">AI-Trace</a>
+          <a href="agents.html">Agents</a>
+          <a href="about.html">About</a>
+          <a href="contact.html">Contact</a>
+        </nav>
+      </div>
+    </header>
+    <main class="container">
+      <section class="page-hero">
+        <p class="eyebrow">Applied Intelligence</p>
+        <h1>Framework</h1>
+        <p class="lead">The framework defines the structural baseline for strategy, operations, and delivery. It aligns modules, pathways, and governance so teams can execute with clarity and consistency.</p>
+      </section>
+      <section class="section">
+        <div class="grid two-up">
+          <article class="card"><h3>Modules</h3><p>Core components establish repeatable standards across business, product, and technical functions.</p></article>
+          <article class="card"><h3>Pathways</h3><p>Defined routes connect objectives to measurable outcomes and continuous optimization loops.</p></article>
+        </div>
+      </section>
+    </main>
+    <footer class="site-footer">
+      <div class="container"><p>Applied Intelligence — Standardize to Optimize.</p></div>
+    </footer>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,94 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Applied Intelligence | Standardize to Optimize</title>
+    <meta
+      name="description"
+      content="Applied Intelligence Framework — public website for framework, AI-Connect, AI-Trace, and ecosystem roles."
+    />
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="container nav-wrap">
+        <a class="brand" href="index.html">Applied Intelligence</a>
+        <nav aria-label="Primary" class="nav-links">
+          <a href="framework.html">Framework</a>
+          <a href="ai-connect.html">AI-Connect</a>
+          <a href="ai-trace.html">AI-Trace</a>
+          <a href="agents.html">Agents</a>
+          <a href="about.html">About</a>
+          <a href="contact.html">Contact</a>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero section container">
+        <div class="hero-copy">
+          <p class="eyebrow">Applied Intelligence Framework</p>
+          <h1>Built from the floor up.</h1>
+          <p class="lead">
+            One ecosystem. Separate agents. Clear roles. Applied Intelligence standardizes the structure so organizations can optimize execution with less friction.
+          </p>
+          <div class="hero-actions">
+            <a class="btn btn-primary" href="framework.html">Explore Framework</a>
+            <a class="btn" href="agents.html">View Agent Roles</a>
+          </div>
+        </div>
+        <div class="device-mock" aria-hidden="true">
+          <div class="device-screen">
+            <div class="mock-topbar"></div>
+            <div class="mock-row"></div>
+            <div class="mock-row short"></div>
+            <div class="mock-card"></div>
+            <div class="mock-grid">
+              <span></span><span></span><span></span><span></span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="section container">
+        <div class="grid three-up">
+          <article class="card">
+            <h2>Standardize</h2>
+            <p>Create shared structure across teams, systems, and delivery functions so execution has a consistent baseline.</p>
+          </article>
+          <article class="card">
+            <h2>Optimize</h2>
+            <p>Use clear roles and measurable pathways to improve quality, speed, and predictability over time.</p>
+          </article>
+          <article class="card">
+            <h2>Scale</h2>
+            <p>Expand with confidence through modular framework components and role-specific agents.</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="section container">
+        <h2 class="section-title">Ecosystem Highlights</h2>
+        <div class="grid two-up">
+          <article class="card feature">
+            <h3>Framework Shell</h3>
+            <p>The website presents the strategic layer: principles, modules, pathways, and alignment.</p>
+            <a href="framework.html">Learn more</a>
+          </article>
+          <article class="card feature">
+            <h3>AI-Connect & AI-Trace</h3>
+            <p>Website pages describe operational intent while runtime implementations live in dedicated app systems.</p>
+            <a href="ai-connect.html">Explore products</a>
+          </article>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container">
+        <p>Applied Intelligence — Standardize to Optimize.</p>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,223 @@
+:root {
+  --bg: #070c16;
+  --bg-elevated: #0d1526;
+  --text: #eaf0ff;
+  --text-soft: #b5c2e0;
+  --line: rgba(255, 255, 255, 0.12);
+  --glow: rgba(70, 136, 255, 0.32);
+  --radius: 18px;
+  --shadow: 0 20px 50px rgba(0, 0, 0, 0.35);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: radial-gradient(circle at 12% 0%, rgba(55, 107, 235, 0.18), transparent 45%), var(--bg);
+  color: var(--text);
+  line-height: 1.65;
+}
+
+a {
+  color: #99bcff;
+  text-decoration: none;
+}
+
+.container {
+  width: min(1120px, 92vw);
+  margin: 0 auto;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  backdrop-filter: blur(14px);
+  background: rgba(7, 12, 22, 0.72);
+  border-bottom: 1px solid var(--line);
+}
+
+.nav-wrap {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 14px 0;
+  gap: 1rem;
+}
+
+.brand {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.nav-links {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.nav-links a {
+  color: var(--text-soft);
+  font-size: 0.95rem;
+}
+
+.section {
+  padding: 3.5rem 0;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: 1.2fr 1fr;
+  gap: 2rem;
+  align-items: center;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #9db9ff;
+  font-size: 0.78rem;
+}
+
+h1,
+h2,
+h3 {
+  line-height: 1.2;
+  margin-top: 0;
+}
+
+h1 {
+  font-size: clamp(2rem, 5vw, 3.5rem);
+  margin-bottom: 0.75rem;
+}
+
+.lead {
+  color: var(--text-soft);
+  max-width: 64ch;
+}
+
+.hero-actions {
+  margin-top: 1.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+}
+
+.btn {
+  display: inline-block;
+  border: 1px solid var(--line);
+  color: var(--text);
+  padding: 0.6rem 1rem;
+  border-radius: 999px;
+}
+
+.btn-primary {
+  background: linear-gradient(135deg, #4b84ff, #3d6ee0);
+  border-color: transparent;
+}
+
+.grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.three-up {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.two-up {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.card {
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.01));
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 1.2rem;
+  box-shadow: var(--shadow);
+}
+
+.section-title {
+  margin-bottom: 1rem;
+}
+
+.device-mock {
+  max-width: 420px;
+  margin-left: auto;
+  padding: 18px;
+  border-radius: 32px;
+  border: 1px solid var(--line);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.02));
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03), 0 16px 40px rgba(0, 0, 0, 0.45);
+}
+
+.device-screen {
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: #0a1222;
+  padding: 14px;
+}
+
+.mock-topbar,
+.mock-row,
+.mock-card,
+.mock-grid span {
+  border-radius: 10px;
+  background: linear-gradient(130deg, rgba(72, 130, 255, 0.7), rgba(72, 130, 255, 0.15));
+}
+
+.mock-topbar {
+  height: 20px;
+  margin-bottom: 12px;
+}
+
+.mock-row {
+  height: 12px;
+  margin-bottom: 8px;
+}
+
+.mock-row.short {
+  width: 70%;
+}
+
+.mock-card {
+  height: 100px;
+  margin-top: 12px;
+}
+
+.mock-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.mock-grid span {
+  height: 45px;
+}
+
+.site-footer {
+  border-top: 1px solid var(--line);
+  margin-top: 2rem;
+  padding: 1.2rem 0 2rem;
+  color: var(--text-soft);
+}
+
+.page-hero {
+  padding: 4rem 0 2rem;
+}
+
+@media (max-width: 900px) {
+  .hero,
+  .two-up,
+  .three-up {
+    grid-template-columns: 1fr;
+  }
+
+  .device-mock {
+    margin: 0;
+  }
+}


### PR DESCRIPTION
### Motivation
- Replace placeholder "Page intentionally present" pages with substantive website content to preserve Applied Intelligence messaging across Framework, AI-Connect, AI-Trace, Agents, About, and Contact.
- Improve the homepage visual and content fidelity while keeping the CSS-only device mock and Cloudflare-safe static `.html` navigation. 
- Produce a maintainable, well-organized `style.css` that supports the visual direction without adding binary assets or rebuilding the site.

### Description
- Added full static pages: `index.html`, `framework.html`, `ai-connect.html`, `ai-trace.html`, `agents.html`, `about.html`, and `contact.html` with consistent Cloudflare-safe `.html` navigation and preserved site messaging. 
- Replaced placeholder content with meaningful copy and structured sections (hero, CTAs, value cards, ecosystem highlights) to make the homepage richer and closer to the reference. 
- Introduced a reorganized `style.css` with design tokens, layout primitives, cards, buttons, responsive rules, and the retained CSS-only device mock for visual context. 
- Preserved repository constraints: no binary assets added, no deployment config changes, and no site rebuilds were performed because no build system exists here.

### Testing
- Verified presence and linkage of modified files using repository file checks (`rg --files` and per-file existence checks for `index.html`, `framework.html`, `ai-connect.html`, `ai-trace.html`, `agents.html`, `about.html`, `contact.html`, and `style.css`), all of which succeeded. 
- Confirmed there is no build step by running `test -f package.json && echo yes || echo no`, which returned negative so `npm run build` was not applicable. 
- Inspected page and stylesheet contents with file previews (`nl`/file dumps) to validate structure and consistent `style.css` references, which showed the expected markup and styles.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f36181892c83238433668dfc032a3e)