### PR TITLE
Refine website source copy, homepage composition, and navigation guidance

### DIFF
--- a/core/bundles/applied-intelligence-website-source.json
+++ b/core/bundles/applied-intelligence-website-source.json
@@ -6,7 +6,9 @@
     "supportingLine": "Applied Intelligence Framework",
     "description": "Applied Intelligence is the parent ecosystem for specialized agents focused on analytics, continuous improvement, case studies, ROI, quoting, corrective action, communication, routing, permissions, and document formatting.",
     "corePrinciple": "One ecosystem. Separate agents. Clear roles.",
-    "version": "2.0"
+    "version": "2.0",
+    "headline": "Standardize to Optimize.",
+    "positioning": "Built from the floor up."
   },
   "repository": {
     "name": "applied-intelligence-website",
@@ -25,14 +27,94 @@
     "summaryFile": "core/summaries/applied-intelligence-website-summary.md"
   },
   "agentCards": [
-    { "id": "ai-trace", "title": "AI-Trace", "subtitle": "Trace", "type": "analytics_visibility", "icon": "magnifier-chart", "color": "blue", "status": "active", "tagline": "AI-Trace exposes repeat problems, hidden cost, quality risk, and lost hours so recurring issues stop being patched and start being fixed.", "principle": "AI-Trace shows the picture clearly. AI-CIS fixes what the picture reveals." },
-    { "id": "ai-cis", "title": "AI-CIS", "subtitle": "CIS", "type": "continuous_improvement", "icon": "shield", "color": "copper", "status": "active", "tagline": "AI-CIS captures process breakdowns, protects flow, and drives corrective action before repeat issues become normal.", "principle": "AI-CIS finds the improvement." },
-    { "id": "ai-roi", "title": "AI-ROI", "subtitle": "ROI", "type": "business_justification", "icon": "bar-chart", "color": "green", "status": "active", "tagline": "AI-ROI turns validated improvements and equipment opportunities into clear financial justification, showing where capacity, labor, and value can be gained.", "principle": "AI-CIS finds the improvement. AI-ROI justifies the value." },
-    { "id": "ai-case", "title": "AI-Case", "subtitle": "Case", "type": "case_study_storytelling", "icon": "document", "color": "indigo", "status": "planned", "tagline": "AI-Case turns real improvements, technical problem-solving, and process wins into clear case studies.", "principle": "AI-CIS identifies case study value. AI-Case tells the story." },
-    { "id": "ai-quote", "title": "AI-Quote", "subtitle": "Quote", "type": "estimating_quoting", "icon": "calculator", "color": "orange", "status": "planned", "tagline": "AI-Quote turns weld, grind, fixture, and flow decisions into clear estimating logic and practical pricing.", "principle": "AI-Quote prices the work clearly." },
-    { "id": "ai-rma", "title": "AI-RMA", "subtitle": "RMA", "type": "return_corrective_action", "icon": "alert-rotate", "color": "red", "status": "planned", "tagline": "AI-RMA traces failures back to the source, contains risk, and drives permanent correction instead of repeat damage.", "principle": "AI-RMA closes the loop." },
-    { "id": "ai-connect", "title": "AI-Connect", "subtitle": "Connect", "type": "communication_routing_permissions", "icon": "network", "color": "teal", "status": "active", "tagline": "AI-Connect prepares the right people with the right information before action is needed.", "principle": "Nothing important gets lost between people, departments, or decisions." },
-    { "id": "document-formatter", "title": "Document Formatter", "subtitle": "Formatter", "type": "support_utility", "icon": "page-wand", "color": "silver", "status": "active", "tagline": "The Document Formatter turns finished outputs into clean, branded documents ready for review, print, or portfolio use.", "principle": "The Document Formatter formats finished outputs cleanly without changing the underlying logic." }
+    {
+      "id": "ai-trace",
+      "title": "AI-Trace",
+      "subtitle": "Trace",
+      "type": "analytics_visibility",
+      "icon": "magnifier-chart",
+      "color": "blue",
+      "status": "active",
+      "tagline": "AI-Trace exposes repeat problems, hidden cost, quality risk, and lost hours so recurring issues stop being patched and start being fixed.",
+      "principle": "AI-Trace shows the picture clearly. AI-CIS fixes what the picture reveals."
+    },
+    {
+      "id": "ai-cis",
+      "title": "AI-CIS",
+      "subtitle": "CIS",
+      "type": "continuous_improvement",
+      "icon": "shield",
+      "color": "copper",
+      "status": "active",
+      "tagline": "AI-CIS captures process breakdowns, protects flow, and drives corrective action before repeat issues become normal.",
+      "principle": "AI-CIS finds the improvement."
+    },
+    {
+      "id": "ai-roi",
+      "title": "AI-ROI",
+      "subtitle": "ROI",
+      "type": "business_justification",
+      "icon": "bar-chart",
+      "color": "green",
+      "status": "active",
+      "tagline": "AI-ROI turns validated improvements and equipment opportunities into clear financial justification, showing where capacity, labor, and value can be gained.",
+      "principle": "AI-CIS finds the improvement. AI-ROI justifies the value."
+    },
+    {
+      "id": "ai-case",
+      "title": "AI-Case",
+      "subtitle": "Case",
+      "type": "case_study_storytelling",
+      "icon": "document",
+      "color": "indigo",
+      "status": "planned",
+      "tagline": "AI-Case turns real improvements, technical problem-solving, and process wins into clear case studies.",
+      "principle": "AI-CIS identifies case study value. AI-Case tells the story."
+    },
+    {
+      "id": "ai-quote",
+      "title": "AI-Quote",
+      "subtitle": "Quote",
+      "type": "estimating_quoting",
+      "icon": "calculator",
+      "color": "orange",
+      "status": "planned",
+      "tagline": "AI-Quote turns weld, grind, fixture, and flow decisions into clear estimating logic and practical pricing.",
+      "principle": "AI-Quote prices the work clearly."
+    },
+    {
+      "id": "ai-rma",
+      "title": "AI-RMA",
+      "subtitle": "RMA",
+      "type": "return_corrective_action",
+      "icon": "alert-rotate",
+      "color": "red",
+      "status": "planned",
+      "tagline": "AI-RMA traces failures back to the source, contains risk, and drives permanent correction instead of repeat damage.",
+      "principle": "AI-RMA closes the loop."
+    },
+    {
+      "id": "ai-connect",
+      "title": "AI-Connect",
+      "subtitle": "Connect",
+      "type": "communication_routing_permissions",
+      "icon": "network",
+      "color": "teal",
+      "status": "active",
+      "tagline": "AI-Connect prepares the right people with the right information before action is needed.",
+      "principle": "Nothing important gets lost between people, departments, or decisions."
+    },
+    {
+      "id": "document-formatter",
+      "title": "Document Formatter",
+      "subtitle": "Formatter",
+      "type": "support_utility",
+      "icon": "page-wand",
+      "color": "silver",
+      "status": "active",
+      "tagline": "The Document Formatter turns finished outputs into clean, branded documents ready for review, print, or portfolio use.",
+      "principle": "The Document Formatter formats finished outputs cleanly without changing the underlying logic."
+    }
   ],
   "ui": {
     "colorMap": {
@@ -54,6 +136,46 @@
       "ai-rma": "alert-rotate",
       "ai-connect": "network",
       "document-formatter": "page-wand"
+    }
+  },
+  "pages": {
+    "home": {
+      "hero": {
+        "headline": "Standardize to Optimize.",
+        "support": "Built from the floor up.",
+        "body": "Applied Intelligence is a structured operating framework that connects visibility, correction, communication, and business justification into one clear system."
+      },
+      "systemOverview": {
+        "title": "System Overview",
+        "body": "The website should show how AI-Trace reveals recurring risk, AI-CIS drives correction, AI-ROI quantifies impact, and AI-Connect routes action to the right people at the right time."
+      },
+      "shellDepth": {
+        "title": "Premium Framework Shell",
+        "body": "Use layered glass surfaces, calm contrast, and structured spacing so the homepage feels premium without visual noise."
+      }
+    },
+    "about": {
+      "title": "About Applied Intelligence",
+      "body": "Applied Intelligence is the public framework layer for an ecosystem of specialized agents designed to improve operational clarity, process reliability, and measurable business outcomes."
+    },
+    "framework": {
+      "title": "Applied Intelligence Framework",
+      "body": "The framework standardizes how issues are seen, corrected, communicated, and justified so teams can optimize performance with consistent methods."
+    },
+    "contact": {
+      "title": "Contact",
+      "body": "Use approved channel messaging only. Do not publish unapproved direct contact details in website content."
+    }
+  },
+  "navigation": {
+    "topNav": {
+      "format": "static_html",
+      "rule": "Preserve static .html navigation patterns and routes."
+    },
+    "bottomDock": {
+      "enabled": true,
+      "style": "restrained_glass",
+      "guidance": "Use a refined bottom dock treatment aligned to the reference direction with clear active state and balanced spacing."
     }
   }
 }

--- a/core/summaries/applied-intelligence-website-summary.md
+++ b/core/summaries/applied-intelligence-website-summary.md
@@ -4,8 +4,22 @@ The Applied Intelligence website serves as the public-facing framework shell for
 
 ## Purpose
 - Present the ecosystem clearly
-- Show agent roles
-- Communicate system value
+- Show agent roles with meaningful copy, not placeholders
+- Communicate system value through homepage-first storytelling
+
+## Homepage Direction
+- Keep the main hero headline as **"Standardize to Optimize."**
+- Keep the support line as **"Built from the floor up."**
+- Strengthen composition with a clear system overview section, agent card depth, and premium shell layering
+
+## Page Copy Standard
+- About, Framework, and Contact pages must use real Applied Intelligence copy
+- Do not leave generic placeholder text such as "presentation page"
+- Do not add unapproved contact details
+
+## Navigation Rules
+- Preserve static `.html` navigation
+- Bottom dock navigation can be used when intentionally refined to match the reference visual direction
 
 ## Key Rules
 - Do not contain execution logic

--- a/docs/WEBSITE_HANDOFF.md
+++ b/docs/WEBSITE_HANDOFF.md
@@ -43,6 +43,15 @@ core/bundles/applied-intelligence-website-source.json
 5. Create PR
 6. Wait for approval
 
+## Current Content Direction
+
+- Homepage must retain **"Standardize to Optimize."** as the headline.
+- Homepage must retain **"Built from the floor up."** as support copy.
+- Replace placeholder inner-page text with authentic Applied Intelligence language.
+- Preserve static `.html` navigation patterns.
+- Refine bottom dock only when intentionally aligned to reference styling.
+- Do not add unapproved contact details.
+
 ## Design Direction
 
 - Clean


### PR DESCRIPTION
### Motivation
- Replace generic placeholder page copy with real Applied Intelligence copy and preserve the established headline and support lines.
- Strengthen homepage direction toward a richer hero, system overview, agent cards, and premium shell depth while keeping the site presentation-only.
- Provide explicit guidance to preserve static `.html` navigation and to refine the bottom dock only when aligned to the reference direction.

### Description
- Updated `core/bundles/applied-intelligence-website-source.json` to add `headline` and `positioning`, a new `pages` object with `home`, `about`, `framework`, and `contact` content, and explicit `navigation`/`bottomDock` guidance.
- Reformatted the `agentCards` entries for readability and left their existing metadata and taglines intact, with no change to binary assets or deployment configuration.
- Extended site documentation by updating `core/summaries/applied-intelligence-website-summary.md` to require meaningful page copy and richer homepage composition, and by updating `docs/WEBSITE_HANDOFF.md` with the current content direction and navigation rules.
- Ensured constraints are explicit: keep "Standardize to Optimize." and "Built from the floor up.", preserve static `.html` nav, and avoid publishing unapproved contact details.

### Testing
- Ran `test -f package.json && npm run build || echo 'No package.json; build not applicable'`, which returned `No package.json; build not applicable` indicating no site build was applicable in this repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f36a4b52a883238b73e6dd9778fc3d)