### PR TITLE
Set up Cloudflare preview-first workflow

### DIFF
--- a/CLOUDFLARE_PREVIEW_WORKFLOW.md
+++ b/CLOUDFLARE_PREVIEW_WORKFLOW.md
@@ -1,0 +1,34 @@
+# Cloudflare Preview Deployment Workflow
+
+Purpose: keep the Applied Intelligence website safe by reviewing preview builds before anything goes live.
+
+## Required Cloudflare behavior
+
+- Production branch: `main`
+- Non-production branch builds: ON
+- Direct production auto-deploy from unreviewed work: OFF when available in Cloudflare settings
+- Work branches should produce preview builds only
+- Live production deploy happens only after an approved PR is merged into `main`
+
+## Repo workflow
+
+1. Create a new branch for every change.
+2. Do not push Codex or manual edits directly to `main`.
+3. Open a pull request from the work branch into `main`.
+4. Review the Cloudflare preview URL.
+5. Merge only when the preview is approved.
+
+## Branch naming
+
+Recommended examples:
+
+- `preview/home-polish`
+- `preview/mobile-showcase`
+- `preview/glass-chrome-refinement`
+- `fix/icon-assets`
+
+## Applied Intelligence rule
+
+The website is the public-facing framework shell. The app is the operating interface.
+
+Use preview first. Merge only after review.


### PR DESCRIPTION
This PR adds a simple Cloudflare preview-first workflow note for the Applied Intelligence website.

Goal:
- Keep `main` as the approved live branch.
- Use work branches for Cloudflare previews.
- Review the preview URL before merging.
- Avoid direct Codex/manual pushes to `main`.

Cloudflare settings still need to be confirmed in the Cloudflare dashboard:
- Production branch: `main`
- Non-production branch builds: ON
- Automatic production deployments: OFF if Cloudflare exposes that toggle for this project type
- Build command/output should match the repo structure

This PR itself is intentionally a preview/test branch so Cloudflare can generate a preview build without changing production.